### PR TITLE
Update non codelingo variables.

### DIFF
--- a/tenets/cacophony/default/no-fmt-print/.lingo
+++ b/tenets/cacophony/default/no-fmt-print/.lingo
@@ -20,7 +20,7 @@ tenets:
         any_of:
           go.import_spec({depth: any}): # aliased import
             go.ident:
-              name: $packageName
+              name as packageName
             go.basic_lit:
               value == "fmt"
           go.import_spec({depth: any}): # unaliased import
@@ -28,11 +28,11 @@ tenets:
               go.ident
             go.basic_lit:
               value == "fmt"
-              value: $packageName
+              value as packageName
         @ review.comment
         go.call_expr({depth: any}):
           go.selector_expr:
             go.ident:
-              name: $packageName
+              name as packageName
             go.ident:
               name: /^Print.*$/

--- a/tenets/west/default/allocation/.lingo
+++ b/tenets/west/default/allocation/.lingo
@@ -12,14 +12,14 @@ tenets:
           cpp.lhs:
             cpp.variable:
               cpp.identifier_name:
-                identifier_token: $varName
+                identifier_token as varName
           cpp.rhs:
             cpp.new_keyword
         @ review.comment
         cpp.free_statement:
           cpp.variable:
             cpp.identifier_name:
-              identifier_token: $varName
+              identifier_token as varName
 
   - name: deleted-malloced-objects
     doc: Finds objects that were obtained with malloc and deleted.
@@ -34,7 +34,7 @@ tenets:
           cpp.lhs:
             cpp.variable:
               cpp.identifier_name:
-                identifier_token: $varName
+                identifier_token as varName
           cpp.rhs:
             cpp.function_call:
               cpp.identifier_name:
@@ -43,7 +43,7 @@ tenets:
           @ review.comment
           cpp.variable:
             cpp.identifier_name:
-              identifier_token: $varName
+              identifier_token as varName
 
   - name: used-after-deletion
     doc: Finds objects used after deletion.
@@ -56,15 +56,15 @@ tenets:
       cpp.delete_statement:
         cpp.variable:
           cpp.identifier_name:
-            identifier_token: $varName
+            identifier_token as varName
       any_of:
         cpp.element:
           cpp.variable({depth: any}):
             cpp.identifier_name:
-              identifier_token: $varName
+              identifier_token as varName
         cpp.variable:
           cpp.identifier_name:
-            identifier_token: $varName
+            identifier_token as varName
 
   - name: undeleted-returned-object
     doc: Finds objects new that are not deleted.
@@ -80,18 +80,18 @@ tenets:
             cpp.variable:
               type: /ref.*/
               cpp.identifier_name:
-                identifier_token: $varName
+                identifier_token as varName
         exclude:
           any_of:
             cpp.delete_statement({depth: any}):
               cpp.variable:
                 cpp.identifier_name:
-                  identifier_token: $varName
+                  identifier_token as varName
             cpp.method_call:
               cpp.variable:
                 cpp.identifier_name:
-                  identifier_token: $varName
+                  identifier_token as varName
             cpp.function_call:
               cpp.variable:
                 cpp.identifier_name:
-                  identifier_token: $varName
+                  identifier_token as varName

--- a/tenets/west/default/shadowing/.lingo
+++ b/tenets/west/default/shadowing/.lingo
@@ -9,12 +9,12 @@ tenets:
 
       cpp.function_decl({depth: any}):
         cpp.parm_decl:
-          name: $paramName
+          name as paramName
         cpp.compound_stmt:
           @ review.comment
           cpp.binary_operator({depth: any}):
             cpp.decl_ref_expr:
-              name: $paramName
+              name as paramName
 
   - name: shadowed-declaration
     doc: Finds declarations that are updated in an inner scope.
@@ -26,9 +26,9 @@ tenets:
 
       cpp.var_decl({depth: any}):
         cpp.parm_decl:
-          name: $varName
+          name as varName
       cpp.compound_stmt({depth: any}):
         @ review.comment
         cpp.binary_operator({depth: any}):
           cpp.decl_ref_expr:
-            name: $varName
+            name as varName


### PR DESCRIPTION
Updates variable syntax outside the tenetes/codelingo directory, which was missed in https://github.com/codelingo/codelingo/pull/58