### PR TITLE
Move Flow SRC from codelingo/lingo repo

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,6 +23,18 @@
   revision = "cd527374f1e5bff4938207604a14f2e38a9cf512"
 
 [[projects]]
+  name = "github.com/blang/semver"
+  packages = ["."]
+  revision = "2ee87856327ba09384cabd113bc6b5d174e9ec0f"
+  version = "v3.5.1"
+
+[[projects]]
+  name = "github.com/briandowns/spinner"
+  packages = ["."]
+  revision = "bbeb66ec3653684a0afb3031087f790a5b7d7bdf"
+  version = "1.3"
+
+[[projects]]
   name = "github.com/codegangsta/cli"
   packages = ["."]
   revision = "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
@@ -30,29 +42,36 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/codelingo/antlr"
-  packages = ["runtime/Go/antlr"]
-  revision = "afe378d7da74af180f7813c50f033de669e0e477"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/codelingo/clql"
-  packages = ["inner"]
-  revision = "606a8d4cfcb6518534d8fd598c40987a711cd3d7"
-  source = "git@github.com:codelingo/clql.git"
-
-[[projects]]
-  branch = "master"
   name = "github.com/codelingo/lingo"
   packages = [
+    "app/commands/verify",
     "app/util",
     "app/util/common",
     "app/util/common/config",
     "service",
     "service/config",
-    "service/grpc/codelingo"
+    "service/grpc",
+    "vcs",
+    "vcs/git",
+    "vcs/p4"
   ]
-  revision = "79bdff3afdac39f6bb530c5616a8d2dc0045109f"
+  revision = "52d0acdf8562ca512204a42693a52ef24baf8c5d"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/codelingo/rpc"
+  packages = [
+    "flow",
+    "flow/client",
+    "service"
+  ]
+  revision = "283372594e0084af67bb2ba8d0b77da19b9c8070"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/codelingo/sdk"
+  packages = ["flow"]
+  revision = "325b3aa4e403c3c1bb6d280e4a90bde22fec7d10"
 
 [[projects]]
   branch = "master"
@@ -104,6 +123,12 @@
   version = "v0.3.3"
 
 [[projects]]
+  name = "github.com/fatih/color"
+  packages = ["."]
+  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
+  version = "v1.7.0"
+
+[[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
@@ -132,6 +157,12 @@
   version = "v1.2"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/gogits/go-gogs-client"
+  packages = ["."]
+  revision = "c84e492d93458e0bb79bfa1810047841d5bb12ae"
+
+[[projects]]
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
@@ -146,8 +177,20 @@
     "ptypes/duration",
     "ptypes/timestamp"
   ]
-  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
-  version = "v1.1.0"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
+
+[[projects]]
+  name = "github.com/google/go-github"
+  packages = ["github"]
+  revision = "f55b50f38167644bb7e4be03d9a2bde71d435239"
+  version = "v18.2.0"
+
+[[projects]]
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -173,6 +216,16 @@
   revision = "89887b2ade6d89e3b322e2e3c8e337ad5c6a447b"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/inconshreveable/go-update"
+  packages = [
+    ".",
+    "internal/binarydist",
+    "internal/osext"
+  ]
+  revision = "8152e7eb6ccf8679a64582a66b78519688d156ad"
+
+[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -180,9 +233,39 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/juju/clock"
+  packages = ["."]
+  revision = "bab88fc672997ef02d03f85310182d97a93dee21"
+
+[[projects]]
+  branch = "master"
   name = "github.com/juju/errors"
   packages = ["."]
   revision = "812b06ada1776ad4dd95d575e18ffffe3a9ac34a"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/juju/loggo"
+  packages = ["."]
+  revision = "584905176618da46b895b176c721b02c476b6993"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/juju/testing"
+  packages = ["checkers"]
+  revision = "472a3e8b2073fb3cd67c12d2bc5f3cd28e5f4116"
+
+[[projects]]
+  name = "github.com/kr/pretty"
+  packages = ["."]
+  revision = "73f6ac0b30a98e433b289500d779f50c1a6f0712"
+  version = "v0.1.0"
+
+[[projects]]
+  name = "github.com/kr/text"
+  packages = ["."]
+  revision = "e2ffdb16a802fe2bb95e2e35ff34f0e53aeef34f"
+  version = "v0.1.0"
 
 [[projects]]
   name = "github.com/magiconair/properties"
@@ -257,6 +340,18 @@
   version = "v0.8.0"
 
 [[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/rhysd/go-github-selfupdate"
+  packages = ["selfupdate"]
+  revision = "4bfc1aa0302c89605b9bf20a8bb4e1af625bc714"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
@@ -302,10 +397,33 @@
   version = "v1.0.2"
 
 [[projects]]
+  name = "github.com/tcnksm/go-gitconfig"
+  packages = ["."]
+  revision = "d154598bacbf4501c095a309753c5d4af66caa81"
+  version = "v0.1.2"
+
+[[projects]]
   name = "github.com/ugorji/go"
   packages = ["codec"]
   revision = "b4c50a2b199d93b13dc15e78929cfb23bfdf21ab"
   version = "v1.1.1"
+
+[[projects]]
+  name = "github.com/ulikunitz/xz"
+  packages = [
+    ".",
+    "internal/hash",
+    "internal/xlog",
+    "lzma"
+  ]
+  revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
+  version = "v0.5.4"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/waigani/diffparser"
+  packages = ["."]
+  revision = "8ef6bf958d9ed965d280547be1a25646044ae6d1"
 
 [[projects]]
   name = "go.uber.org/atomic"
@@ -355,6 +473,15 @@
 
 [[projects]]
   branch = "master"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal"
+  ]
+  revision = "c57b0facaced709681d9f90397429b9430a74754"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -384,6 +511,20 @@
   version = "v0.3.0"
 
 [[projects]]
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
+  revision = "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06"
+  version = "v1.2.0"
+
+[[projects]]
   branch = "master"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
@@ -405,7 +546,9 @@
     "internal",
     "internal/backoff",
     "internal/channelz",
+    "internal/envconfig",
     "internal/grpcrand",
+    "internal/transport",
     "keepalive",
     "metadata",
     "naming",
@@ -415,11 +558,16 @@
     "resolver/passthrough",
     "stats",
     "status",
-    "tap",
-    "transport"
+    "tap"
   ]
-  revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
-  version = "v1.13.0"
+  revision = "8dea3dc473e90c8179e519d91302d0597c0ca1d1"
+  version = "v1.15.0"
+
+[[projects]]
+  branch = "v1"
+  name = "gopkg.in/check.v1"
+  packages = ["."]
+  revision = "788fd78401277ebd861206a03c884797c6ec5541"
 
 [[projects]]
   name = "gopkg.in/fatih/color.v1"
@@ -432,6 +580,33 @@
   packages = ["."]
   revision = "5f1438d3fca68893a817e4a66806cea46a9e4ebf"
   version = "v8.18.2"
+
+[[projects]]
+  branch = "v1"
+  name = "gopkg.in/juju/worker.v1"
+  packages = ["."]
+  revision = "e63ca51523be524b34f05ffa0c62eed10e231f8f"
+
+[[projects]]
+  branch = "v2"
+  name = "gopkg.in/mgo.v2"
+  packages = [
+    "bson",
+    "internal/json"
+  ]
+  revision = "9856a29383ce1c59f308dd1cf0363a79b5bef6b5"
+
+[[projects]]
+  branch = "v1"
+  name = "gopkg.in/tomb.v1"
+  packages = ["."]
+  revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
+
+[[projects]]
+  branch = "v2"
+  name = "gopkg.in/tomb.v2"
+  packages = ["."]
+  revision = "d5d1b5820637886def9eef33e03a27a9f166942c"
 
 [[projects]]
   branch = "v1"
@@ -448,6 +623,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c7ea257717afc8857f56f34a4583e3f0db1398fe815f6fc45f8d4b47b9d74b09"
+  inputs-digest = "71c10246654241b24129daeb0adbb37fbf5fd8405f16a7c2ba958975b78c9d54"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/flows/codelingo/docs/main.go
+++ b/flows/codelingo/docs/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"github.com/codegangsta/cli"
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/sdk/flow"
+	"github.com/juju/errors"
+)
+
+var docsCommand = cli.Command{
+	Name:  "docs",
+	Usage: "Generate documentation from Tenets",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  util.OutputFlg.String(),
+			Usage: "File to save found results to.",
+		},
+		cli.StringFlag{
+			Name:  "template, t",
+			Value: "default",
+			Usage: "The template to use when generating docs.",
+		},
+	},
+	Description: `
+""$ lingo docs" .
+`[1:],
+	Action: docsAction,
+}
+
+func main() {
+	if err := flow.Run(docsCommand); err != nil {
+		flow.HandleErr(err)
+	}
+}
+
+func docsAction(ctx *cli.Context) {
+	docs, err := docsCMD(ctx)
+	if err != nil {
+
+		// Debugging
+		util.Logger.Debugw("docsAction", "err_stack", errors.ErrorStack(err))
+
+		util.FatalOSErr(err)
+		return
+	}
+
+	if ctx.IsSet("template") || ctx.IsSet("t") {
+		print("template")
+	} else {
+
+		print(docs)
+	}
+
+}
+
+func docsCMD(cliCtx *cli.Context) (string, error) {
+	return "docs", nil
+}

--- a/flows/codelingo/pull-request/main.go
+++ b/flows/codelingo/pull-request/main.go
@@ -1,0 +1,106 @@
+package flows
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/codegangsta/cli"
+	"github.com/codelingo/codelingo/flows/codelingo/review/review"
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/rpc/flow"
+	flowutil "github.com/codelingo/sdk/flow"
+	"github.com/juju/errors"
+)
+
+var pullRequestCmd = cli.Command{
+	Name:      "pull-request",
+	ShortName: "pr",
+	Usage:     "review a remote pull-request",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  util.LingoFile.String(),
+			Usage: "A list of codelingo.yaml files to perform the review with. If the flag is not set, codelingo.yaml files are read from the branch being reviewed.",
+		},
+		// TODO(waigani) as this is a review sub-command, it should be able to use the
+		// lingo-file flag from review.
+		// cli.BoolFlag{
+		// 	Name:  "all",
+		// 	Usage: "review all files under all directories from pwd down",
+		// },
+	},
+	Description: `
+"$ lingo review pull-request https://github.com/codelingo/lingo/pull/1" will review all code in the diff between the pull request and it's base repository.
+"$ lingo review pr https://github.com/codelingo/lingo/pull/1" will review all code in the diff between the pull request and it's base repository.
+`[1:],
+	// "$ lingo review" will review any unstaged changes from pwd down.
+	// "$ lingo review [<filename>]" will review any unstaged changes in the named files.
+	// "$ lingo review --all [<filename>]" will review all code in the named files.
+	Action: reviewPullRequestAction,
+}
+
+func main() {
+	if err := flowutil.Run(pullRequestCmd); err != nil {
+		flowutil.HandleErr(err)
+	}
+}
+
+func reviewPullRequestAction(ctx *cli.Context) {
+	msg, err := reviewPullRequestCMD(ctx)
+	if err != nil {
+		// Debugging
+		// print(errors.ErrorStack(err))
+		util.FatalOSErr(err)
+		return
+	}
+	fmt.Println(msg)
+}
+
+func reviewPullRequestCMD(cliCtx *cli.Context) (string, error) {
+	if l := len(cliCtx.Args()); l != 1 {
+		return "", errors.Errorf("expected one arg, got %d", l)
+	}
+
+	dotlingo, err := review.ReadDotLingo(cliCtx)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	opts, err := review.ParsePR(cliCtx.Args()[0])
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	ctx, cancel := util.UserCancelContext(context.Background())
+	issuec, errorc, err := review.RequestReview(ctx, &flow.ReviewRequest{
+		Host:     opts.Host,
+		Hostname: opts.HostName,
+		// TODO (Junyu) separate it into two separate fields
+		OwnerOrDepot: &flow.ReviewRequest_Owner{opts.Owner},
+		Repo:         opts.Name,
+		// Sha and patches are defined by the PR
+		IsPullRequest: true,
+		PullRequestID: int64(opts.PRID),
+		Dotlingo:      dotlingo,
+	})
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	issues, err := review.ConfirmIssues(cancel, issuec, errorc, cliCtx.Bool("keep-all"), cliCtx.String("save"))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	// TODO: streaming back to the client, verify issues on the client side.
+	if len(issues) == 0 {
+		return "Done! No issues found.\n", nil
+	}
+
+	msg, err := review.MakeReport(issues, cliCtx.String("format"), cliCtx.String("save"))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	fmt.Println(fmt.Printf("Done! Found %d issues \n", len(issues)))
+	return msg, nil
+}

--- a/flows/codelingo/review/main.go
+++ b/flows/codelingo/review/main.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/codelingo/codelingo/flows/codelingo/review/review"
+	"github.com/codelingo/lingo/app/commands/verify"
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/lingo/app/util/common/config"
+	"github.com/codelingo/lingo/vcs"
+	"github.com/codelingo/rpc/flow"
+	flowutil "github.com/codelingo/sdk/flow"
+	"github.com/juju/errors"
+)
+
+const (
+	vcsGit string = "git"
+	vcsP4  string = "perforce"
+)
+
+var reviewCommand = cli.Command{
+	Name:  "review",
+	Usage: "Review code following tenets in codelingo.yaml.",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  util.LingoFile.String(),
+			Usage: "A codelingo.yaml file to perform the review with. If the flag is not set, codelingo.yaml files are read from the branch being reviewed.",
+		},
+		cli.StringFlag{
+			Name:  util.DiffFlg.String(),
+			Usage: "Review only unstaged changes in the working tree.",
+		},
+		cli.StringFlag{
+			Name:  util.OutputFlg.String(),
+			Usage: "File to save found issues to.",
+		},
+		cli.StringFlag{
+			Name:  util.FormatFlg.String(),
+			Value: "json-pretty",
+			Usage: "How to format the found issues. Possible values are: json, json-pretty.",
+		},
+		cli.BoolFlag{
+			Name:  util.KeepAllFlg.String(),
+			Usage: "Keep all issues and don't be prompted to confirm each issue.",
+		},
+		cli.StringFlag{
+			Name:  util.DirectoryFlg.String(),
+			Usage: "Review a given directory.",
+		},
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "Display debug messages",
+		},
+		// cli.BoolFlag{
+		// 	Name:  "all",
+		// 	Usage: "review all files under all directories from pwd down",
+		// },
+	},
+	Description: `
+"$ lingo review" will review all code from pwd down.
+"$ lingo review <filename>" will only review named file.
+`[1:],
+	// "$ lingo review" will review any unstaged changes from pwd down.
+	// "$ lingo review [<filename>]" will review any unstaged changes in the named files.
+	// "$ lingo review --all [<filename>]" will review all code in the named files.
+	Action: reviewAction,
+}
+
+func main() {
+	if err := flowutil.Run(reviewCommand); err != nil {
+		flowutil.HandleErr(err)
+	}
+}
+
+func reviewAction(ctx *cli.Context) {
+	err := reviewRequire()
+	if err != nil {
+		util.FatalOSErr(err)
+		return
+	}
+
+	msg, err := reviewCMD(ctx)
+	if err != nil {
+		if ctx.IsSet("debug") {
+			// Debugging
+			util.Logger.Debugw("reviewAction", "err_stack", errors.ErrorStack(err))
+		}
+		util.FatalOSErr(err)
+		return
+	}
+
+	fmt.Println(msg)
+}
+
+func reviewRequire() error {
+	reqs := []verify.Require{verify.VCSRq, verify.HomeRq, verify.AuthRq, verify.ConfigRq, verify.VersionRq}
+	for _, req := range reqs {
+		err := req.Verify()
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func reviewCMD(cliCtx *cli.Context) (string, error) {
+	defer util.Logger.Sync()
+	if cliCtx.IsSet("debug") {
+		util.Logger.Debugw("reviewCMD called")
+	}
+	dir := cliCtx.String("directory")
+	if dir != "" {
+		if err := os.Chdir(dir); err != nil {
+			return "", errors.Trace(err)
+		}
+	}
+
+	dotlingo, err := review.ReadDotLingo(cliCtx)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	vcsType, repo, err := vcs.New()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	// TODO: replace this system with nfs-like communication.
+	fmt.Println("Syncing your repo...")
+	if err = vcs.SyncRepo(vcsType, repo); err != nil {
+		return "", errors.Trace(err)
+	}
+
+	owner, name, err := repo.OwnerAndNameFromRemote()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	sha, err := repo.CurrentCommitId()
+	if err != nil {
+		if flowutil.NoCommitErr(err) {
+			return "", errors.New(flowutil.NoCommitErrMsg)
+		}
+
+		return "", errors.Trace(err)
+	}
+
+	patches, err := repo.Patches()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	var patchesSize int64
+	for _, patch := range patches {
+		patchesSize += int64(len([]byte(patch)))
+	}
+	if patchesSize >= 1024*1024 { // >= 1MB; default max GRPC msg size accepted by the servers is 4MB.
+		util.UserFacingWarning("Warning: large diffs can be error prone. You may need to commit your changes.")
+	}
+
+	workingDir, err := repo.WorkingDir()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	cfg, err := config.Platform()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	vcsTypeStr, err := vcs.TypeToString(vcsType)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	ctx, cancel := util.UserCancelContext(context.Background())
+	issuec := make(chan *flow.Issue)
+	errorc := make(chan error)
+
+	req := &flow.ReviewRequest{
+		Repo:     name,
+		Sha:      sha,
+		Patches:  patches,
+		Vcs:      vcsTypeStr,
+		Dir:      workingDir,
+		Dotlingo: dotlingo,
+	}
+	switch vcsTypeStr {
+	case vcsGit:
+		addr, err := cfg.GitServerAddr()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		hostname, err := cfg.GitRemoteName()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+
+		req.Host = addr
+		req.Hostname = hostname
+		req.OwnerOrDepot = &flow.ReviewRequest_Owner{owner}
+	case vcsP4:
+		addr, err := cfg.P4ServerAddr()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		hostname, err := cfg.P4RemoteName()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		depot, err := cfg.P4RemoteDepotName()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		name = owner + "/" + name
+
+		req.Host = addr
+		req.Hostname = hostname
+		req.OwnerOrDepot = &flow.ReviewRequest_Depot{depot}
+		req.Repo = name
+	default:
+		return "", errors.Errorf("Invalid VCS '%s'", vcsTypeStr)
+	}
+
+	fmt.Println("Running review flow...")
+	issuec, errorc, err = review.RequestReview(ctx, req)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	issues, err := review.ConfirmIssues(cancel, issuec, errorc, cliCtx.Bool("keep-all"), cliCtx.String("output"))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	if len(issues) == 0 {
+		return fmt.Sprintf("Done! No issues found.\n"), nil
+	}
+
+	// Remove dicarded issues from report
+	keptIssues := []*flow.Issue{}
+	for _, issue := range issues {
+		if !issue.Discard {
+			keptIssues = append(keptIssues, issue)
+		}
+	}
+
+	// TODO(waigani) send back all issues and capture false positives.
+
+	msg, err := review.MakeReport(keptIssues, cliCtx.String("format"), cliCtx.String("output"))
+	return msg, errors.Trace(err)
+}

--- a/flows/codelingo/review/review.txt
+++ b/flows/codelingo/review/review.txt
@@ -1,0 +1,10 @@
+Found 2 errors in 2 files
+
+review/review.go
+13: imports are organised incorrectly. They should be ordered in the following three groups: stdLib, 3rd Party, Juju 
+
+
+review/review_test.go
+8: imports are organised incorrectly. They should be ordered in the following three groups: stdLib, 3rd Party, Juju 
+
+

--- a/flows/codelingo/review/review/checksyntax.go
+++ b/flows/codelingo/review/review/checksyntax.go
@@ -1,0 +1,60 @@
+package review
+
+// TODO(waigani) refactor below to be called on lingo review. use `lingo
+// review --dry-run` if user only wants to check syntax.
+
+// package main
+
+// import (
+// 	"fmt"
+// 	. "github.com/codelingo/clql/preprocessor"
+// 	"github.com/fatih/color"
+// 	"io/ioutil"
+// 	"os"
+// 	"path/filepath"
+// )
+
+// func main() {
+// 	if len(os.Args) == 1 {
+// 		fmt.Println("Codelingo syntax checker\nUsage: ./checksyntax [dot-lingo-file-path] [extra] [verbose]")
+// 		return
+// 	}
+
+// 	verbose := 1
+// 	if len(os.Args) >= 3 {
+// 		verbose = 2
+// 	}
+
+// 	path, err := filepath.Abs(os.Args[1])
+// 	if err == nil {
+// 		fmt.Println("Reading the .lingo file at " + path)
+// 		filebytes, err := ioutil.ReadFile(path)
+// 		if err != nil {
+// 			fmt.Println("Failed to open and read file " + path)
+// 			return
+// 		}
+
+// 		m, er := Process(string(filebytes), verbose)
+
+// 		if er == nil {
+// 			color.Cyan("=== LINGO SYNTAX AND SEMANTICS PASS ALL CHECKS ===")
+// 			color.Cyan("%s", path)
+// 		} else {
+// 			color.Red("=== LINGO SYNTAX AND SEMANTIC CHECK FAILED ===")
+// 			color.Red("%s", path)
+// 			color.Yellow(er.Error())
+// 		}
+
+// 		if len(os.Args) == 4 {
+// 			// extra verbose, dump the map
+// 			color.Cyan("\nYAML MAP FROM PREPROCESSOR:")
+// 			fmt.Println(m)
+// 		}
+
+// 	} else {
+// 		fmt.Println("Could not find file: " + os.Args[1])
+// 		return
+// 	}
+
+// 	return
+// }

--- a/flows/codelingo/review/review/confirm.go
+++ b/flows/codelingo/review/review/confirm.go
@@ -1,0 +1,150 @@
+package review
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/rpc/flow"
+	"github.com/fatih/color"
+	"github.com/waigani/diffparser"
+)
+
+type IssueConfirmer struct {
+	keepAll bool
+	output  bool
+}
+
+func NewConfirmer(output, keepAll bool, d *diffparser.Diff) (*IssueConfirmer, error) {
+	cfm := IssueConfirmer{
+		keepAll: keepAll,
+		output:  output,
+	}
+
+	return &cfm, nil
+}
+
+func GetDiffRootPath(filename string) string {
+	// Get filename relative to git root folder
+	// TODO: Handle error in case of git not being installed
+	// https://github.com/codelingo/demo/issues/2
+	out, err := exec.Command("git", "ls-tree", "--full-name", "--name-only", "HEAD", filename).Output()
+	if err == nil && len(out) != 0 {
+		if len(out) != 0 {
+			filename = strings.TrimSuffix(string(out), "\n")
+		}
+	}
+	return filename
+}
+
+var editor string
+
+// confirm returns true if the issue should be kept or false if it should be
+// dropped.
+func (c IssueConfirmer) Confirm(attempt int, issue *flow.Issue) bool {
+	if c.keepAll {
+		return true
+	}
+	if attempt == 0 {
+		fmt.Println(c.FormatPlainText(issue))
+	}
+	attempt++
+	var options string
+	fmt.Print("\n[o]pen")
+	if c.output {
+		fmt.Print(" [d]iscard [k]eep")
+	}
+	fmt.Print(": ")
+
+	fmt.Scanln(&options)
+
+	switch options {
+	case "o":
+		var app string
+		defaultEditor := "vi" // TODO(waigani) use EDITOR or VISUAL env vars
+		// https://github.com/codelingo/demo/issues/3
+		if editor != "" {
+			defaultEditor = editor
+		}
+		fmt.Printf("application (%s):", defaultEditor)
+		fmt.Scanln(&app)
+		filename := issue.Position.Start.Filename
+		if app == "" {
+			app = defaultEditor
+		}
+		// c := issue.Position.Start.Column // TODO(waigani) use column
+		// https://github.com/codelingo/demo/issues/4
+		l := issue.Position.Start.Line
+		cmd, err := util.OpenFileCmd(app, filename, l)
+		if err != nil {
+			fmt.Println(err)
+			return c.Confirm(attempt, issue)
+		}
+
+		if err = cmd.Start(); err != nil {
+			log.Println(err)
+		}
+		if err = cmd.Wait(); err != nil {
+			log.Println(err)
+		}
+
+		editor = app
+
+		c.Confirm(attempt, issue)
+	case "d":
+		issue.Discard = true
+
+		// TODO(waigani) only prompt for reason if we're sending to a service.
+		// https://github.com/codelingo/demo/issues/5
+		//fmt.Print("reason: ")
+		//in := bufio.NewReader(os.Stdin)
+		//issue.DiscardReason, _ = in.ReadString('\n')
+
+		// TODO(waigani) we are now always returning true. Need to decide
+		// how caller will deal with removing isseus, ie. KeptIssues vs AllIssues,
+		// then being returning false here
+		// https://github.com/codelingo/demo/issues/6
+		return true
+	case "", "k", "K", "\n":
+		return true
+	default:
+		fmt.Printf("invalid input: %s\n", options)
+		fmt.Println(options)
+		c.Confirm(attempt, issue)
+	}
+
+	return true
+}
+
+func (c *IssueConfirmer) FormatPlainText(issue *flow.Issue) string {
+	m := color.New(color.FgWhite, color.Faint).SprintfFunc()
+	y := color.New(color.FgYellow).SprintfFunc()
+	yf := color.New(color.FgYellow, color.Faint).SprintfFunc()
+	cy := color.New(color.FgCyan).SprintfFunc()
+	filename := issue.Position.Start.Filename
+
+	addrFmtStr := fmt.Sprintf("%s:%d", filename, issue.Position.End.Line)
+	if col := issue.Position.End.Column; col != 0 {
+		addrFmtStr += fmt.Sprintf(":%d", col)
+	}
+	address := m(addrFmtStr)
+	comment := strings.Trim(issue.Comment, "\n")
+	comment = cy(indent("\n"+comment+"\n", false))
+
+	ctxBefore := indent(yf("\n...\n%s", issue.CtxBefore), false)
+	issueLines := indent(y("\n%s", issue.LineText), true)
+	ctxAfter := indent(yf("\n%s\n...", issue.CtxAfter), false)
+	src := ctxBefore + issueLines + ctxAfter
+
+	return fmt.Sprintf("%s\n%s\n%s", address, comment, src)
+}
+
+func indent(str string, point bool) string {
+	replace := "\n    "
+	if point {
+		replace = "\n  > "
+	}
+	return strings.Replace(str, "\n", replace, -1)
+}

--- a/flows/codelingo/review/review/review.go
+++ b/flows/codelingo/review/review/review.go
@@ -1,0 +1,272 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"sync"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/briandowns/spinner"
+	"github.com/codegangsta/cli"
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/lingo/service"
+	grpcclient "github.com/codelingo/lingo/service/grpc"
+	"github.com/codelingo/rpc/flow"
+	"github.com/codelingo/rpc/flow/client"
+	"github.com/juju/errors"
+)
+
+func RequestReview(ctx context.Context, req *flow.ReviewRequest) (chan *flow.Issue, chan error, error) {
+	conn, err := service.GrpcConnection(service.LocalClient, service.FlowServer)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	c := client.NewFlowClient(conn)
+
+	// Create context with metadata
+	ctx, err = grpcclient.AddUsernameToCtx(ctx)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	payload, err := ptypes.MarshalAny(req)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	// TODO(waigani) refactor review, search and codemod code out of client completely.
+	replyc, runErrc, err := c.Run(ctx, &flow.Request{Flow: "review", Payload: payload})
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	issuec := make(chan *flow.Issue)
+	errc := make(chan error)
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		for err := range runErrc {
+			errc <- err
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for reply := range replyc {
+
+			issue := &flow.Issue{}
+			ptypes.UnmarshalAny(reply.Payload, issue)
+			if err != nil {
+				errc <- err
+				continue
+			}
+
+			issuec <- issue
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		wg.Wait()
+		close(issuec)
+		close(errc)
+	}()
+
+	return issuec, errc, nil
+}
+
+func MakeReport(issues []*flow.Issue, format, outputFile string) (string, error) {
+	var data []byte
+	var err error
+	switch format {
+	case "json":
+		data, err = json.Marshal(issues)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	case "json-pretty":
+		data, err = json.MarshalIndent(issues, " ", " ")
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	default:
+		return "", errors.Errorf("Unknown format %q", format)
+	}
+
+	if outputFile != "" {
+		err = ioutil.WriteFile(outputFile, data, 0775)
+		if err != nil {
+			return "", errors.Annotate(err, "Error writing issues to file")
+		}
+		return fmt.Sprintf("Done! %d issues written to %s \n", len(issues), outputFile), nil
+	}
+
+	return string(data), nil
+}
+
+// Read a codelingo.yaml file from a filepath argument
+func ReadDotLingo(ctx *cli.Context) (string, error) {
+	var dotlingo []byte
+
+	if filename := ctx.String(util.LingoFile.Long); filename != "" {
+		var err error
+		dotlingo, err = ioutil.ReadFile(filename)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	}
+	return string(dotlingo), nil
+}
+
+func ConfirmIssues(cancel context.CancelFunc, issuec chan *flow.Issue, errorc chan error, keepAll bool, saveToFile string) ([]*flow.Issue, error) {
+	defer util.Logger.Sync()
+
+	var confirmedIssues []*flow.Issue
+	spnr := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	spnr.Start()
+	defer spnr.Stop()
+
+	output := saveToFile == ""
+	cfm, err := NewConfirmer(output, keepAll, nil)
+	if err != nil {
+		cancel()
+		return nil, errors.Trace(err)
+	}
+
+	// If user is manually confirming reviews, set a long timeout.
+	timeout := time.After(time.Hour * 1)
+
+l:
+	for {
+		select {
+		case err, ok := <-errorc:
+			if !ok {
+				errorc = nil
+				break
+			}
+
+			// Abort review
+			cancel()
+			util.Logger.Debugf("Review error: %s", errors.ErrorStack(err))
+			return nil, errors.Trace(err)
+		case iss, ok := <-issuec:
+			if !ok {
+				issuec = nil
+				if !keepAll {
+					spnr.Stop()
+				}
+				break
+			}
+
+			// Flow server checking the connection; can be safely ignored.
+			if iss.IsHeartbeat {
+				continue
+			}
+
+			if !keepAll {
+				spnr.Stop()
+			}
+
+			// TODO: remove errors from issues; there's a separate channel for that
+			if iss.Err != "" {
+				// Abort review
+				cancel()
+				return nil, errors.New(iss.Err)
+			}
+
+			if cfm.Confirm(0, iss) {
+				confirmedIssues = append(confirmedIssues, iss)
+			}
+
+			if !keepAll {
+				spnr.Restart()
+			}
+		case <-timeout:
+			cancel()
+			return nil, errors.New("timed out waiting for issue")
+		}
+		if issuec == nil && errorc == nil {
+			break l
+		}
+	}
+
+	// Stop spinner if it hasn't been stopped already
+	if keepAll {
+		spnr.Stop()
+	}
+	return confirmedIssues, nil
+}
+
+func NewRange(filename string, startLine, endLine int) *flow.IssueRange {
+	start := &flow.Position{
+		Filename: filename,
+		Line:     int64(startLine),
+	}
+
+	end := &flow.Position{
+		Filename: filename,
+		Line:     int64(endLine),
+	}
+
+	return &flow.IssueRange{
+		Start: start,
+		End:   end,
+	}
+}
+
+// TODO(waigani) simplify representation of Issue.
+// https://github.com/codelingo/demo/issues/7
+// type Issue struct {
+// 	apiIssue
+// 	TenetName     string `json:"tenetName,omitempty"`
+// 	Discard       bool   `json:"discard,omitempty"`
+// 	DiscardReason string `json:"discardReason,omitempty"`
+// }
+
+// type apiIssue struct {
+// 	// The name of the issue.
+// 	TenetName     string            `json:"tenetName,omitempty"`
+// 	Discard       bool              `json:"discard,omitempty"`
+// 	DiscardReason string            `json:"discardReason,omitempty"`
+// 	Name          string            `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+// 	Position      *IssueRange       `protobuf:"bytes,2,opt,name=position" json:"position,omitempty"`
+// 	Comment       string            `protobuf:"bytes,3,opt,name=comment" json:"comment,omitempty"`
+// 	CtxBefore     string            `protobuf:"bytes,4,opt,name=ctxBefore" json:"ctxBefore,omitempty"`
+// 	LineText      string            `protobuf:"bytes,5,opt,name=lineText" json:"lineText,omitempty"`
+// 	CtxAfter      string            `protobuf:"bytes,6,opt,name=ctxAfter" json:"ctxAfter,omitempty"`
+// 	Metrics       map[string]string `protobuf:"bytes,7,rep,name=metrics" json:"metrics,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+// 	Tags          []string          `protobuf:"bytes,8,rep,name=tags" json:"tags,omitempty"`
+// 	Link          string            `protobuf:"bytes,9,opt,name=link" json:"link,omitempty"`
+// 	NewCode       bool              `protobuf:"varint,10,opt,name=newCode" json:"newCode,omitempty"`
+// 	Patch         string            `protobuf:"bytes,11,opt,name=patch" json:"patch,omitempty"`
+// 	Err           string            `protobuf:"bytes,12,opt,name=err" json:"err,omitempty"`
+// }
+
+// type IssueRange struct {
+// 	Start *Position `protobuf:"bytes,1,opt,name=start" json:"start,omitempty"`
+// 	End   *Position `protobuf:"bytes,2,opt,name=end" json:"end,omitempty"`
+// }
+
+// type Position struct {
+// 	Filename string `protobuf:"bytes,1,opt,name=filename" json:"filename,omitempty"`
+// 	Offset   int64  `protobuf:"varint,2,opt,name=Offset" json:"Offset,omitempty"`
+// 	Line     int64  `protobuf:"varint,3,opt,name=Line" json:"Line,omitempty"`
+// 	Column   int64  `protobuf:"varint,4,opt,name=Column" json:"Column,omitempty"`
+// }
+
+type Options struct {
+	// TODO(waigani) validate PullRequest
+	PullRequest  string
+	FilesAndDirs []string
+	Diff         bool   // ctx.Bool("diff") TODO(waigani) this should be a sub-command which proxies to git diff
+	SaveToFile   string // ctx.String("save")
+	KeepAll      bool   // ctx.Bool("keep-all")
+	DotLingo     string // ctx.Bool("lingo-file")
+	// TODO(waigani) add KeepAllWithTag. Use this for CLAIR autoreviews
+	// TODO(waigani) add streaming json output
+}

--- a/flows/codelingo/review/review/review_test.go
+++ b/flows/codelingo/review/review/review_test.go
@@ -1,0 +1,24 @@
+package review
+
+import (
+	"testing"
+
+	jc "github.com/juju/testing/checkers"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type reviewSuite struct{}
+
+var _ = Suite(&reviewSuite{})
+
+func (s *reviewSuite) TestParseURL(c *C) {
+	urlStr := "https://github.com/waigani/codelingo_demo/pull/1"
+	_, err := ParsePR(urlStr)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/flows/codelingo/review/review/reviewpr.go
+++ b/flows/codelingo/review/review/reviewpr.go
@@ -1,0 +1,74 @@
+// The review package contains helper methods to create review requests to be sent to the bot
+// endpoint layer, especially CLAIR.
+package review
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+type PROpts struct {
+	Host     string
+	HostName string
+	Owner    string
+	Name     string
+	PRID     int
+}
+
+// ParsePR produces a set of PROpts to be sent to CLAIR in the bot endpoint layer
+func ParsePR(urlStr string) (*PROpts, error) {
+	// TODO: Try to parse urlStr as a request for each VCS host
+
+	result, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var parts []string
+	parts = strings.Split(strings.Trim(result.Path, "/"), "/")
+	switch result.Host {
+	case "github.com":
+		opts, err := parseGithubPR(parts)
+		return opts, errors.Trace(err)
+	case "gitlab.com":
+		opts, err := parseGitlabPR(parts)
+		return opts, errors.Trace(err)
+	case "bitbucket.com":
+		opts, err := parseBitBucketPR(parts)
+		return opts, errors.Trace(err)
+	default:
+		return nil, errors.Errorf("Unrecognised host %s", result.Host)
+	}
+}
+
+func parseGithubPR(urlPath []string) (*PROpts, error) {
+	if l := len(urlPath); l != 4 {
+		return nil, errors.Errorf("Github pull request URL needs to be in the following format: https://github.com/<username>/<repo_name>/pull/<pull_number>")
+	}
+
+	n, err := strconv.Atoi(urlPath[3])
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &PROpts{
+		Host:     "github.com",
+		HostName: "github_com",
+		Owner:    urlPath[0],
+		Name:     urlPath[1],
+		PRID:     n,
+	}, nil
+}
+
+// TODO: implement
+func parseBitBucketPR(urlStr []string) (*PROpts, error) {
+	return nil, errors.New("BitBucket not supported.")
+}
+
+// TODO: implement
+func parseGitlabPR(urlStr []string) (*PROpts, error) {
+	return nil, errors.New("Gitlab not supported.")
+}

--- a/flows/codelingo/rewrite/main.go
+++ b/flows/codelingo/rewrite/main.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/codelingo/codelingo/flows/codelingo/rewrite/rewrite"
+
+	"github.com/codelingo/lingo/app/commands/verify"
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/lingo/app/util/common/config"
+	"github.com/codelingo/lingo/vcs"
+	"github.com/codelingo/rpc/flow"
+	flowutil "github.com/codelingo/sdk/flow"
+	"github.com/juju/errors"
+)
+
+var rewriteCmd = cli.Command{
+	Name:  "rewrite",
+	Usage: "Modify code following tenets in codelingo.yaml.",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  util.LingoFile.String(),
+			Usage: "A codelingo.yaml file to perform the review with. If the flag is not set, codelingo.yaml files are read from the branch being reviewed.",
+		},
+		cli.StringFlag{
+			Name:  util.DiffFlg.String(),
+			Usage: "Review only unstaged changes in the working tree.",
+		},
+		cli.StringFlag{
+			Name:  util.OutputFlg.String(),
+			Usage: "File to save found issues to.",
+		},
+		cli.StringFlag{
+			Name:  util.FormatFlg.String(),
+			Value: "json-pretty",
+			Usage: "How to format the found issues. Possible values are: json, json-pretty.",
+		},
+		cli.BoolFlag{
+			Name:  util.KeepAllFlg.String(),
+			Usage: "Keep all issues and don't be prompted to confirm each issue.",
+		},
+		cli.StringFlag{
+			Name:  util.DirectoryFlg.String(),
+			Usage: "Modify a given directory.",
+		},
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "Display debug messages",
+		},
+		// cli.BoolFlag{
+		// 	Name:  "all",
+		// 	Usage: "review all files under all directories from pwd down",
+		// },
+	},
+	Description: `
+"$ lingo review" will review all code from pwd down.
+"$ lingo review <filename>" will only review named file.
+`[1:],
+	// "$ lingo review" will review any unstaged changes from pwd down.
+	// "$ lingo review [<filename>]" will review any unstaged changes in the named files.
+	// "$ lingo review --all [<filename>]" will review all code in the named files.
+	Action: rewriteAction,
+}
+
+func main() {
+	if err := flowutil.Run(rewriteCmd); err != nil {
+		flowutil.HandleErr(err)
+	}
+}
+
+func rewriteAction(ctx *cli.Context) {
+	err := rewriteRequire()
+	if err != nil {
+		util.FatalOSErr(err)
+		return
+	}
+
+	msg, err := rewriteCMD(ctx)
+	if err != nil {
+		if ctx.IsSet("debug") {
+			// Debugging
+			util.Logger.Debugw("rewriteAction", "err_stack", errors.ErrorStack(err))
+		}
+		util.FatalOSErr(err)
+		return
+	}
+
+	fmt.Println(msg)
+}
+
+func rewriteRequire() error {
+	reqs := []verify.Require{verify.VCSRq, verify.HomeRq, verify.AuthRq, verify.ConfigRq, verify.VersionRq}
+	for _, req := range reqs {
+		err := req.Verify()
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func rewriteCMD(cliCtx *cli.Context) (string, error) {
+	defer util.Logger.Sync()
+	if cliCtx.IsSet("debug") {
+		util.Logger.Debugw("rewriteCMD called")
+	}
+	dir := cliCtx.String("directory")
+	if dir != "" {
+		if err := os.Chdir(dir); err != nil {
+			return "", errors.Trace(err)
+		}
+	}
+
+	dotlingo, err := rewrite.ReadDotLingo(cliCtx)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	vcsType, repo, err := vcs.New()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	// TODO: replace this system with nfs-like communication.
+	fmt.Println("Syncing your repo...")
+	if err = vcs.SyncRepo(vcsType, repo); err != nil {
+		return "", errors.Trace(err)
+	}
+
+	owner, name, err := repo.OwnerAndNameFromRemote()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	sha, err := repo.CurrentCommitId()
+	if err != nil {
+		if noCommitErr(err) {
+			return "", errors.New(noCommitErrMsg)
+		}
+
+		return "", errors.Trace(err)
+	}
+
+	patches, err := repo.Patches()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	workingDir, err := repo.WorkingDir()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	cfg, err := config.Platform()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	vcsTypeStr, err := vcs.TypeToString(vcsType)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	ctx, cancel := util.UserCancelContext(context.Background())
+	issuec := make(chan *flow.Issue)
+	errorc := make(chan error)
+
+	req := &flow.ReviewRequest{
+		Repo:     name,
+		Sha:      sha,
+		Patches:  patches,
+		Vcs:      vcsTypeStr,
+		Dir:      workingDir,
+		Dotlingo: dotlingo,
+	}
+	switch vcsTypeStr {
+	case vcsGit:
+		addr, err := cfg.GitServerAddr()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		hostname, err := cfg.GitRemoteName()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+
+		req.Host = addr
+		req.Hostname = hostname
+		req.OwnerOrDepot = &flow.ReviewRequest_Owner{owner}
+	case vcsP4:
+		addr, err := cfg.P4ServerAddr()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		hostname, err := cfg.P4RemoteName()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		depot, err := cfg.P4RemoteDepotName()
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+		name = owner + "/" + name
+
+		req.Host = addr
+		req.Hostname = hostname
+		req.OwnerOrDepot = &flow.ReviewRequest_Depot{depot}
+		req.Repo = name
+	default:
+		return "", errors.Errorf("Invalid VCS '%s'", vcsTypeStr)
+	}
+
+	fmt.Println("Running rewrite flow...")
+	issuec, errorc, err = rewrite.RequestReview(ctx, req)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	issues, err := rewrite.ConfirmIssues(cancel, issuec, errorc, cliCtx.Bool("keep-all"), cliCtx.String("output"))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	if len(issues) == 0 {
+		return fmt.Sprintf("Done! No issues found.\n"), nil
+	}
+
+	// Remove dicarded issues from report
+	var keptIssues []*rewrite.SRCHunk
+	for _, issue := range issues {
+		if !issue.Discard {
+			keptIssues = append(keptIssues, issue)
+		}
+	}
+	return "", errors.Trace(rewrite.Write(keptIssues))
+}

--- a/flows/codelingo/rewrite/rewrite/codemod.go
+++ b/flows/codelingo/rewrite/rewrite/codemod.go
@@ -1,0 +1,198 @@
+package rewrite
+
+import (
+	"bytes"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+type SRCHunk struct {
+	Filename    string
+	StartOffset int64
+	EndOffset   int64
+	SRC         string
+	Discard     bool
+}
+
+func toString(node interface{}) (string, error) {
+	var b bytes.Buffer
+	fset := &token.FileSet{}
+	if err := format.Node(&b, fset, node); err != nil {
+		return "", errors.Trace(err)
+	}
+	return b.String(), nil
+}
+
+func ClqlToSrc(clql string) (hunks map[string]string, err error) {
+	return nil, errors.New("currently unavailable; WIP flow")
+
+	// TODO(waigani) currently only supports one hunk / @rewrite.set decorator
+
+	//hunks = make(map[string]string)
+	//clqlQueryAST, err := inner.ParseString(clql)
+	//if err != nil {
+	//	//xxx.Print(clql)
+	//	util.Logger.Infof("clql: %s", clql)
+	//	return nil, errors.Trace(err)
+	//}
+	//
+	//root := clqlQueryAST.GetFactTree()
+	//
+	//var finalASTs []interface{}
+	//for _, child := range root.GetChildren() {
+	//	childFact := child.GetFact()
+	//	if namespace := childFact.ID.GetNamespace(); namespace != "go" {
+	//		return nil, errors.Errorf("expected go namespace, got: %s", namespace)
+	//
+	//	}
+	//	// build ast node from fact.
+	//	parentKind := snakeCaseToCamelCase(childFact.ID.GetKind())
+	//	astChildNode := astFactory[parentKind]()
+	//
+	//	// add all properties to node.
+	//	for _, grandChild := range childFact.GetChildren() {
+	//		processElm(astChildNode, childFact, grandChild, hunks)
+	//	}
+	//	// collect all nodes
+	//	finalASTs = append(finalASTs, astChildNode)
+	//}
+	//
+	//// print asts
+	//for _, node := range finalASTs {
+	//
+	//	// funcDeclNode := node.(*ast.FuncDecl)
+	//	// funcDeclNode.Body = new(ast.BlockStmt)
+	//	// funcDeclNode.Type = new(ast.FuncType)
+	//	//	funcDeclNode.Doc = new(ast.CommentGroup)
+	//	// funcDeclNode.Recv = new(ast.FieldList)
+	//	//	funcDeclNode.Doc = new(ast.CommentGroup)
+	//
+	//	//	xxx.Dump(node)
+	//
+	//	src, err := toString(node)
+	//
+	//	if err != nil {
+	//		return nil, errors.Trace(err)
+	//	}
+	//
+	//	// DEMOWARE(waigani) hardcoding to default key for now.
+	//	hunks["_default"] = src
+	//}
+	//return hunks, nil
+}
+
+//func processElm(astParentNode interface{}, parent *inner.Fact, childElm *inner.Element, srcs map[string]string) {
+//
+//	parentKind := snakeCaseToCamelCase(parent.ID.GetKind())
+//	var value interface{}
+//	//var isFact bool
+//	var name string
+//
+//	// TODO(waigani) transform name
+//	if prop := childElm.GetProperty(); prop != nil {
+//		name = snakeCaseToCamelCase(prop.Name)
+//		value = propertyConvert(parentKind, name, prop)
+//	}
+//
+//	if childFact := childElm.GetFact(); childFact != nil {
+//
+//		childFactKind := snakeCaseToCamelCase(childFact.ID.GetKind())
+//		if factory, ok := astFactory[childFactKind]; ok {
+//			value = factory()
+//		} else {
+//			util.Logger.Infof("need new fact: %s", childFactKind)
+//		}
+//
+//		// process every child Elm of the fact, add properties to the node.
+//		for _, grandChildElm := range childFact.GetChildren() {
+//			processElm(value, childFact, grandChildElm, srcs)
+//		}
+//
+//		// TODO(waigani) transform name
+//		name = snakeCaseToCamelCase(childFact.GetID().GetKind())
+//
+//		// TODO(waigani) workout parent field name by matching fact types
+//		// hardcoding for now
+//		name = "Name"
+//
+//		//isFact = true
+//	}
+//
+//	// xxx.Print("child: " + name)
+//
+//	// set the ast field
+//	astParentNodeVal := reflect.ValueOf(astParentNode).Elem()
+//
+//	f := astParentNodeVal.FieldByName(name)
+//	if f.IsValid() && f.CanSet() {
+//		f.Set(reflect.ValueOf(value))
+//	} else {
+//		// xxx.Print("field not found: " + name + " for parent: " + parentKind)
+//	}
+//
+//}
+
+var astFactory = map[string]func() interface{}{
+	"Decls": func() interface{} {
+		return new([]ast.Decl)
+	},
+	"Decl": func() interface{} {
+		return new(ast.Decl)
+	},
+	"FuncDecl": func() interface{} {
+		return new(ast.FuncDecl)
+	},
+	"Ident": func() interface{} {
+		return new(ast.Ident)
+	},
+	"AssignStmt": func() interface{} {
+		return new(ast.AssignStmt)
+	},
+	"BinaryExpr": func() interface{} {
+		return new(ast.BinaryExpr)
+	},
+	"IfStmt": func() interface{} {
+		return new(ast.IfStmt)
+	},
+	"CallExpr": func() interface{} {
+		return new(ast.CallExpr)
+	},
+}
+
+//func propertyConvert(parent, field string, in *inner.Property) interface{} {
+//
+//	switch parent + "." + field {
+//	case "Ident.NamePos":
+//		return token.Pos(in.GetInt())
+//	}
+//
+//	return in.GetString_()
+//
+//}
+
+func snakeCaseToCamelCase(inputUnderScoreStr string) (camelCase string) {
+	isToUpper := false
+
+	for k, v := range inputUnderScoreStr {
+		if k == 0 {
+			camelCase = strings.ToUpper(string(inputUnderScoreStr[0]))
+		} else {
+			if isToUpper {
+				camelCase += strings.ToUpper(string(v))
+				isToUpper = false
+			} else {
+				if v == '_' {
+					isToUpper = true
+				} else {
+					camelCase += string(v)
+				}
+			}
+		}
+	}
+	return
+
+}

--- a/flows/codelingo/rewrite/rewrite/confirm.go
+++ b/flows/codelingo/rewrite/rewrite/confirm.go
@@ -1,0 +1,157 @@
+package rewrite
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/rpc/flow"
+	"github.com/fatih/color"
+	"github.com/waigani/diffparser"
+)
+
+type IssueConfirmer struct {
+	keepAll bool
+	output  bool
+}
+
+func NewConfirmer(output, keepAll bool, d *diffparser.Diff) (*IssueConfirmer, error) {
+	cfm := IssueConfirmer{
+		keepAll: keepAll,
+		output:  output,
+	}
+
+	return &cfm, nil
+}
+
+func GetDiffRootPath(filename string) string {
+	// Get filename relative to git root folder
+	// TODO: Handle error in case of git not being installed
+	// https://github.com/codelingo/demo/issues/2
+	out, err := exec.Command("git", "ls-tree", "--full-name", "--name-only", "HEAD", filename).Output()
+	if err == nil && len(out) != 0 {
+		if len(out) != 0 {
+			filename = strings.TrimSuffix(string(out), "\n")
+		}
+	}
+	return filename
+}
+
+var editor string
+
+// confirm returns true if the issue should be kept or false if it should be
+// dropped.
+func (c IssueConfirmer) Confirm(attempt int, issue *flow.Issue, newSRC string) bool {
+	if c.keepAll {
+		return true
+	}
+	if attempt == 0 {
+		fmt.Println(c.FormatPlainText(issue, newSRC))
+	}
+	attempt++
+	var options string
+	fmt.Print("\n[o]pen")
+	if c.output {
+		fmt.Print(" [k]eep [R]eplace")
+	}
+	fmt.Print(": ")
+
+	fmt.Scanln(&options)
+
+	switch options {
+	case "o":
+		var app string
+		defaultEditor := "vi" // TODO(waigani) use EDITOR or VISUAL env vars
+		// https://github.com/codelingo/demo/issues/3
+		if editor != "" {
+			defaultEditor = editor
+		}
+		fmt.Printf("application (%s):", defaultEditor)
+		fmt.Scanln(&app)
+		filename := issue.Position.Start.Filename
+		if app == "" {
+			app = defaultEditor
+		}
+		// c := issue.Position.Start.Column // TODO(waigani) use column
+		// https://github.com/codelingo/demo/issues/4
+		l := issue.Position.Start.Line
+		cmd, err := util.OpenFileCmd(app, filename, l)
+		if err != nil {
+			fmt.Println(err)
+			return c.Confirm(attempt, issue, newSRC)
+		}
+
+		if err = cmd.Start(); err != nil {
+			log.Println(err)
+		}
+		if err = cmd.Wait(); err != nil {
+			log.Println(err)
+		}
+
+		editor = app
+
+		c.Confirm(attempt, issue, newSRC)
+	case "k":
+		issue.Discard = true
+
+		// TODO(waigani) only prompt for reason if we're sending to a service.
+		// https://github.com/codelingo/demo/issues/5
+		fmt.Print("reason: ")
+		in := bufio.NewReader(os.Stdin)
+		issue.DiscardReason, _ = in.ReadString('\n')
+
+		// TODO(waigani) we are now always returning true. Need to decide
+		// how caller will deal with removing isseus, ie. KeptIssues vs AllIssues,
+		// then being returning false here
+		// https://github.com/codelingo/demo/issues/6
+		return true
+	case "", "r", "R", "\n":
+		return true
+	default:
+		fmt.Printf("invalid input: %s\n", options)
+		fmt.Println(options)
+		c.Confirm(attempt, issue, newSRC)
+	}
+
+	// TODO(waigani) build up issues here.
+
+	return true
+}
+
+func (c *IssueConfirmer) FormatPlainText(issue *flow.Issue, newSRC string) string {
+	m := color.New(color.FgWhite, color.Faint).SprintfFunc()
+	y := color.New(color.FgRed).SprintfFunc()
+	yf := color.New(color.FgWhite, color.Faint).SprintfFunc()
+	g := color.New(color.FgGreen).SprintfFunc()
+	filename := issue.Position.Start.Filename
+
+	addrFmtStr := fmt.Sprintf("%s:%d", filename, issue.Position.End.Line)
+	if col := issue.Position.End.Column; col != 0 {
+		addrFmtStr += fmt.Sprintf(":%d", col)
+	}
+	address := m(addrFmtStr)
+
+	ctxBefore := indent(yf("\n...\n%s", issue.CtxBefore), false, false)
+	oldLines := indent(y("\n%s", issue.LineText), false, true)
+
+	newLines := indent(g("\n%s", newSRC), true, false)
+	ctxAfter := indent(yf("\n%s\n...", issue.CtxAfter), false, false)
+	src := ctxBefore + oldLines + newLines + ctxAfter
+
+	return fmt.Sprintf("%s\n%s", address, src)
+}
+
+func indent(str string, add, remove bool) string {
+	replace := "\n    "
+	if add {
+		replace = "\n  + "
+	}
+	if remove {
+		replace = "\n  - "
+	}
+	return strings.Replace(str, "\n", replace, -1)
+}

--- a/flows/codelingo/rewrite/rewrite/review.go
+++ b/flows/codelingo/rewrite/rewrite/review.go
@@ -1,0 +1,361 @@
+package rewrite
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/briandowns/spinner"
+	"github.com/codegangsta/cli"
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/lingo/service"
+	grpcclient "github.com/codelingo/lingo/service/grpc"
+	"github.com/codelingo/rpc/flow"
+	"github.com/codelingo/rpc/flow/client"
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
+)
+
+func RequestReview(ctx context.Context, req *flow.ReviewRequest) (chan *flow.Issue, chan error, error) {
+
+	// // mock request result while testing
+	// issc := make(chan *flow.Issue)
+	// errc := make(chan error)
+	// go func() {
+	// 	defer close(issc)
+	// 	defer close(errc)
+	// 	issc <- &flow.Issue{
+	// 		CtxBefore: "before",
+	// 		CtxAfter:  "after",
+	// 		LineText:  "line text",
+	// 		Comment:   "this is comment",
+	// 		Position: &flow.IssueRange{
+	// 			Start: &flow.Position{
+	// 				Filename: "main.go",
+	// 				Offset:   10,
+	// 				Line:     2,
+	// 			},
+	// 			End: &flow.Position{
+	// 				Filename: "main.go",
+	// 				Offset:   30,
+	// 				Line:     3,
+	// 			},
+	// 		},
+	// 	}
+	// }()
+	// return issc, errc, nil
+
+	conn, err := service.GrpcConnection(service.LocalClient, service.FlowServer)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	c := client.NewFlowClient(conn)
+
+	// Create context with metadata
+	ctx, err = grpcclient.AddUsernameToCtx(ctx)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	payload, err := ptypes.MarshalAny(req)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	// TODO(waigani) refactor review, search and rewrite code out of client completely.
+	replyc, runErrc, err := c.Run(ctx, &flow.Request{Flow: "rewrite", Payload: payload})
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	issuec := make(chan *flow.Issue)
+	errc := make(chan error)
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		for err := range runErrc {
+			errc <- err
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		for reply := range replyc {
+
+			issue := &flow.Issue{}
+			ptypes.UnmarshalAny(reply.Payload, issue)
+			if err != nil {
+				errc <- err
+				continue
+			}
+
+			issuec <- issue
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		wg.Wait()
+		close(issuec)
+		close(errc)
+	}()
+
+	return issuec, errc, nil
+}
+
+func MakeReport(issues []*flow.Issue, format, outputFile string) (string, error) {
+	var data []byte
+	var err error
+	switch format {
+	case "json":
+		data, err = json.Marshal(issues)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	case "json-pretty":
+		data, err = json.MarshalIndent(issues, " ", " ")
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	default:
+		return "", errors.Errorf("Unknown format %q", format)
+	}
+
+	if outputFile != "" {
+		err = ioutil.WriteFile(outputFile, data, 0775)
+		if err != nil {
+			return "", errors.Annotate(err, "Error writing issues to file")
+		}
+		return fmt.Sprintf("Done! %d issues written to %s \n", len(issues), outputFile), nil
+	}
+
+	return string(data), nil
+}
+
+// Read a codelingo.yaml file from a filepath argument
+func ReadDotLingo(ctx *cli.Context) (string, error) {
+	var dotlingo []byte
+
+	if filename := ctx.String(util.LingoFile.Long); filename != "" {
+		var err error
+		dotlingo, err = ioutil.ReadFile(filename)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	}
+	return string(dotlingo), nil
+}
+
+func ConfirmIssues(cancel context.CancelFunc, issuec chan *flow.Issue, errorc chan error, keepAll bool, saveToFile string) ([]*SRCHunk, error) {
+	defer util.Logger.Sync()
+
+	var confirmedIssues []*SRCHunk
+	spnr := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
+	spnr.Start()
+	defer spnr.Stop()
+
+	output := saveToFile == ""
+	cfm, err := NewConfirmer(output, keepAll, nil)
+	if err != nil {
+		cancel()
+		return nil, errors.Trace(err)
+	}
+
+	// If user is manually confirming reviews, set a long timeout.
+	timeout := time.After(time.Hour * 1)
+	if keepAll {
+		timeout = time.After(time.Minute * 5)
+	}
+
+l:
+	for {
+		select {
+		case err, ok := <-errorc:
+			if !ok {
+				errorc = nil
+				break
+			}
+
+			// Abort review
+			cancel()
+			util.Logger.Debugf("Review error: %s", errors.ErrorStack(err))
+			return nil, errors.Trace(err)
+		case iss, ok := <-issuec:
+			if !keepAll {
+				spnr.Stop()
+			}
+			if !ok {
+				issuec = nil
+				break
+			}
+
+			// TODO: remove errors from issues; there's a separate channel for that
+			if iss.Err != "" {
+				// Abort review
+				cancel()
+				return nil, errors.New(iss.Err)
+			}
+
+			// TODO(waigani) attach Tenet to issue
+			// DEMOWARE hardcoding clql to one in root dir
+			dLingoStr, err := ioutil.ReadFile("codelingo.yaml")
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			type out struct {
+				Tenets []struct {
+					Bots  map[string]map[string]interface{}
+					Query string
+				}
+			}
+
+			var dLingo out
+			err = yaml.Unmarshal(dLingoStr, &dLingo)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			clqlStr := "import codelingo/ast/go\n" + iss.Comment
+
+			// support one set decorator per query.
+			srcs, err := ClqlToSrc(string(clqlStr))
+			if err != nil {
+				return nil, err
+			}
+
+			// TODO(waigani) align issue with set id. Until then, we can only support one set decorator
+			src := srcs["_default"]
+
+			// add full lines for user confirmation
+			confirmSRC, err := fullLineSRC(iss, src)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			if cfm.Confirm(0, iss, confirmSRC) {
+
+				issuePos := iss.Position
+				startPos := issuePos.GetStart()
+
+				// TODO(waigani) offsets need to be based off rewrite decorator, not review.
+				confirmedIssues = append(confirmedIssues, &SRCHunk{
+					StartOffset: startPos.Offset,
+					EndOffset:   issuePos.GetEnd().Offset,
+					SRC:         src,
+					Filename:    startPos.Filename,
+				})
+			}
+
+			if !keepAll {
+				spnr.Restart()
+			}
+		case <-timeout:
+			cancel()
+			return nil, errors.New("timed out waiting for issue")
+		}
+		if issuec == nil && errorc == nil {
+			break l
+		}
+	}
+
+	// Stop spinner if it hasn't been stopped already
+	if keepAll {
+		spnr.Stop()
+	}
+	return confirmedIssues, nil
+}
+
+// returns the full lines of the SRC for the issue.
+func fullLineSRC(issue *flow.Issue, newSRC string) (string, error) {
+
+	pos := issue.GetPosition()
+	startPos := pos.GetStart()
+	endPos := pos.GetEnd()
+
+	file, err := os.Open(startPos.Filename)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	var byt int64
+	var src []byte
+	var strtLineByt int64
+	var endLineByt int64
+	var foundStart bool
+	var foundEnd bool
+	for scanner.Scan() {
+		src = append(src, append(scanner.Bytes(), []byte("\n")...)...)
+
+		startByt := byt
+		endByt := startByt + int64(len(scanner.Bytes())+1) // +1 for \n char
+
+		if startPos.Offset >= startByt && startPos.Offset <= endByt {
+
+			// found start line
+			strtLineByt = startByt
+			foundStart = true
+		}
+
+		if endPos.Offset >= startByt && endPos.Offset <= endByt {
+
+			// found end line
+			endLineByt = endByt
+			foundEnd = true
+		}
+
+		if foundStart && foundEnd {
+
+			// xxx.Print(string(src))
+			// fmt.Printf("\n[%d:%d]", strtLineByt, startPos.Offset)
+			beforeNewSRC := string(src[strtLineByt:startPos.Offset])
+			endNewSRC := string(src[endPos.Offset:endLineByt])
+
+			return beforeNewSRC + newSRC + endNewSRC, nil
+
+		}
+
+		byt = endByt
+	}
+
+	return "", errors.Trace(scanner.Err())
+}
+
+func NewRange(filename string, startLine, endLine int) *flow.IssueRange {
+	start := &flow.Position{
+		Filename: filename,
+		Line:     int64(startLine),
+	}
+
+	end := &flow.Position{
+		Filename: filename,
+		Line:     int64(endLine),
+	}
+
+	return &flow.IssueRange{
+		Start: start,
+		End:   end,
+	}
+}
+
+type Options struct {
+	// TODO(waigani) validate PullRequest
+	PullRequest  string
+	FilesAndDirs []string
+	Diff         bool   // ctx.Bool("diff") TODO(waigani) this should be a sub-command which proxies to git diff
+	SaveToFile   string // ctx.String("save")
+	KeepAll      bool   // ctx.Bool("keep-all")
+	DotLingo     string // ctx.Bool("lingo-file")
+	// TODO(waigani) add KeepAllWithTag. Use this for CLAIR autoreviews
+	// TODO(waigani) add streaming json output
+}

--- a/flows/codelingo/rewrite/rewrite/writer.go
+++ b/flows/codelingo/rewrite/rewrite/writer.go
@@ -1,0 +1,62 @@
+package rewrite
+
+import (
+	"fmt"
+	"io/ioutil"
+	"sort"
+
+	"github.com/juju/errors"
+)
+
+func Write(newSRCs []*SRCHunk) error {
+
+	// TODO(waigani) use one open file handler per file to write all changes
+	// and use a buffered writer: https://www.devdungeon.com/content/working-
+	// files-go#write_buffered
+
+	// first group all issues by file
+	issueMap := make(map[string][]*SRCHunk)
+
+	for _, newSRC := range newSRCs {
+		issueMap[newSRC.Filename] = append(issueMap[newSRC.Filename], newSRC)
+	}
+
+	for filename, issues := range issueMap {
+
+		fileSRC, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		// then order issues by start offset such that we apply the
+		// modifications to the file from the bottom up.
+		sort.Sort(byOffset(issues))
+		var i int
+		var issue *SRCHunk
+		for i, issue = range issues {
+			fileSRC = append(fileSRC[0:issue.StartOffset], append([]byte(issue.SRC), fileSRC[issue.EndOffset:]...)...)
+		}
+
+		if err := ioutil.WriteFile(filename, []byte(fileSRC), 0644); err != nil {
+			return errors.Trace(err)
+		}
+		fmt.Printf("%d modifications made to file %s\n", i, filename)
+
+	}
+
+	return nil
+}
+
+type byOffset []*SRCHunk
+
+func (o byOffset) Len() int {
+	return len(o)
+}
+
+func (o byOffset) Swap(i, j int) {
+	o[i], o[j] = o[j], o[i]
+}
+
+func (o byOffset) Less(i, j int) bool {
+	return o[j].StartOffset < o[i].StartOffset
+}

--- a/flows/codelingo/search/main.go
+++ b/flows/codelingo/search/main.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/golang/protobuf/ptypes"
+
+	"github.com/codegangsta/cli"
+	"github.com/codelingo/lingo/app/commands/verify"
+	"github.com/codelingo/lingo/app/util"
+	"github.com/codelingo/lingo/service"
+	grpcclient "github.com/codelingo/lingo/service/grpc"
+	"github.com/codelingo/rpc/flow"
+	"github.com/codelingo/rpc/flow/client"
+	flowutil "github.com/codelingo/sdk/flow"
+	"github.com/juju/errors"
+)
+
+var searchCommand = cli.Command{
+	Name:  "search",
+	Usage: "Search code following queries in rpc.yaml.",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  util.OutputFlg.String(),
+			Usage: "File to save found results to.",
+		},
+		cli.StringFlag{
+			Name:  util.FormatFlg.String(),
+			Value: "json-pretty",
+			Usage: "How to format the found results. Possible values are: json, json-pretty.",
+		},
+	},
+	Description: `
+""$ lingo search <filename>" .
+`[1:],
+	Action: searchAction,
+}
+
+func main() {
+	if err := flowutil.Run(searchCommand); err != nil {
+		flowutil.HandleErr(err)
+	}
+}
+
+func searchAction(ctx *cli.Context) {
+	err := searchRequire()
+	if err != nil {
+		util.FatalOSErr(err)
+		return
+	}
+
+	msg, err := searchCMD(ctx)
+	if err != nil {
+
+		// Debugging
+		util.Logger.Debugw("searchAction", "err_stack", errors.ErrorStack(err))
+
+		util.FatalOSErr(err)
+		return
+	}
+
+	fmt.Println(msg)
+}
+
+func searchRequire() error {
+	reqs := []verify.Require{verify.HomeRq, verify.AuthRq, verify.ConfigRq, verify.VersionRq}
+	for _, req := range reqs {
+		err := req.Verify()
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func searchCMD(cliCtx *cli.Context) (string, error) {
+	defer util.Logger.Sync()
+	util.Logger.Debugw("searchCMD called")
+
+	args := cliCtx.Args()
+	if len(args) == 0 {
+		return "", errors.New("Please specify the filepath to a rpc.yaml file.")
+	}
+
+	dotlingo, err := ioutil.ReadFile(args[0])
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	conn, err := service.GrpcConnection(service.LocalClient, service.FlowServer)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	c := client.NewFlowClient(conn)
+	ctx, cancel := util.UserCancelContext(context.Background())
+
+	// Create context with metadata
+	ctx, err = grpcclient.AddUsernameToCtx(ctx)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	payload, err := ptypes.MarshalAny(&flow.SearchRequest{
+		Dotlingo: string(dotlingo)})
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	fmt.Println("Running search flow...")
+	resultc, errorc, err := c.Run(ctx, &flow.Request{
+		Flow:    "search",
+		Payload: payload,
+	})
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	results := []*flow.SearchReply{}
+
+l:
+	for {
+		select {
+		case err, ok := <-errorc:
+			if !ok {
+				errorc = nil
+				break
+			}
+
+			// Abort search
+			cancel()
+			util.Logger.Debugf("Search error: %s", errors.ErrorStack(err))
+			return "", errors.Trace(err)
+		case result, ok := <-resultc:
+			if !ok {
+				resultc = nil
+				break
+			}
+
+			if result.Error != "" {
+				cancel()
+				return "", errors.New(result.Error)
+			}
+
+			searchResult := &flow.SearchReply{}
+			if err := ptypes.UnmarshalAny(result.Payload, searchResult); err != nil {
+				return "", errors.Annotate(err, "could not unmarshal search result")
+			}
+
+			results = append(results, searchResult)
+		}
+		if resultc == nil && errorc == nil {
+			break l
+		}
+	}
+
+	msg, err := OutputResults(results, cliCtx.String("format"), cliCtx.String("output"))
+	return msg, errors.Trace(err)
+}
+
+func OutputResults(results []*flow.SearchReply, format, outputFile string) (string, error) {
+	var data []byte
+	var err error
+	switch format {
+	case "json":
+		data, err = json.Marshal(results)
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	case "json-pretty":
+		data, err = json.MarshalIndent(results, " ", " ")
+		if err != nil {
+			return "", errors.Trace(err)
+		}
+	default:
+		return "", errors.Errorf("Unknown format %q", format)
+	}
+
+	if outputFile != "" {
+		err = ioutil.WriteFile(outputFile, data, 0775)
+		if err != nil {
+			return "", errors.Annotate(err, "Error writing results to file")
+		}
+		return fmt.Sprintf("Done! %d results written to %s \n", len(results), outputFile), nil
+	}
+
+	return string(data), nil
+}


### PR DESCRIPTION
Remove hardcoded Flow endpoints from the lingo client into this repo. An
`install flow` command will be added to the client to install the given Flow
cli endpoint.