### PR TITLE
Fix go bundle

### DIFF
--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -6,10 +6,14 @@ tenets:
   - global-var
   - golint
   - goto
+  - init
   - marshalling
   - nil_only_functions
+  - println-format-strings
+  - reallocated_slice
   - sprintf
-  - todo
+  - tested
+  - unconvert
 tags:
   - golang
   - go

--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -3,6 +3,7 @@ version: 0.0.0
 tenets:
   - bool-param
   - empty-slice
+  - global-var
   - golint
   - goto
   - marshalling

--- a/tenets/codelingo/go/todo/README.md
+++ b/tenets/codelingo/go/todo/README.md
@@ -1,0 +1,6 @@
+# todo 
+
+_by codelingo, part of their go bundle_
+
+
+[Load up in the codelingo.io/playground](https://codelingo.io/playground/?repo=github.com/codelingo/hub&dir=tenets/codelingo/go/todo&tenet=codelingo/go/todo)

--- a/tenets/codelingo/go/todo/codelingo.yaml
+++ b/tenets/codelingo/go/todo/codelingo.yaml
@@ -1,0 +1,20 @@
+tenets:
+  - name: todo-comments
+    flows:
+      codelingo/docs:
+        title: Todo Comments
+        body: |
+          Find comments containing TODO.
+
+          TODOs should be tracked in a place outside of the code to ensure they aren't forgotten.
+      codelingo/review:
+        comment: Make sure you add this TODO as an issue, milestone, or in your project management tool; eg. Trello.
+    query: |
+      import (
+        codelingo/ast/go
+      )
+
+      @review comment
+      go.comment(depth = any):
+        text as todoText
+        regex(/(?i)(^|\s)TODO.*/, todoText)

--- a/tenets/codelingo/go/todo/example.go
+++ b/tenets/codelingo/go/todo/example.go
@@ -1,0 +1,29 @@
+package main
+
+import "log"
+
+// todo: all lower case
+
+// tOdO: mixed case
+
+// TODO: upper case
+
+// todo no colon
+
+// gasdTodo--
+
+// main is the entry point to this example
+func main() {
+	err := serve()
+	if err != nil {
+		log.Fatal(err.Error()) // TODO: check error type before exiting
+	}
+}
+
+// What about this comment?
+
+// serve runs the server, returning an error if it crashes
+func serve() error {
+	// TODO: implement server
+	return nil
+}


### PR DESCRIPTION
Keep the TODO tenet, but remove it from the Go bundle so that it still works for files that import it.

Add tenets in the bundle directory, but not in the bundle yaml.