### PR TITLE
JSON Help

### DIFF
--- a/flows/codelingo/review/review/decorator.go
+++ b/flows/codelingo/review/review/decorator.go
@@ -15,7 +15,7 @@ import (
 var DecoratorApp = &flowutil.DecoratorApp{
 	App: cli.App{
 		Name:  "review",
-		Usage: "Review code following tenets in codelingo.yaml.",
+		Usage: "Comment on the decorated code.",
 		Flags: []cli.Flag{},
 	},
 	ConfirmDecorated: decoratorAction,

--- a/flows/codelingo/rewrite/rewrite/decorator.go
+++ b/flows/codelingo/rewrite/rewrite/decorator.go
@@ -13,7 +13,8 @@ import (
 
 var DecoratorApp = &flowutil.DecoratorApp{
 	App: cli.App{
-		Name: "rewrite",
+		Name:  "rewrite",
+		Usage: "Replace the decorated node with the new code",
 		Flags: []cli.Flag{
 			cli.BoolFlag{
 				Name:  "replace, r",

--- a/sdk/flow/help.go
+++ b/sdk/flow/help.go
@@ -104,3 +104,14 @@ var INFOTMP = `
    {{end}}
 
 `[1:]
+
+type helpData struct {
+	Name, Tagline, Description, Version, LastCompiled string
+	Options                                           []string
+	Decorator                                         decHelp
+}
+
+type decHelp struct {
+	Description, Example string
+	Options              []string
+}


### PR DESCRIPTION
Add an internal command, _genJSONHelp to each flow. This command writes the
help data to a .json file. Usage: `lingo run <flow> _genJSONHelp <pathToJSONFile>.