### PR TITLE
Move unsafe go routine tenet from platform.

### DIFF
--- a/tenets/codelingo/go/unsafe-go-routine-variables/codelingo.yaml
+++ b/tenets/codelingo/go/unsafe-go-routine-variables/codelingo.yaml
@@ -1,0 +1,25 @@
+tenets:
+  - name: unsafe-go-routine-variables
+    flows:
+      codelingo/docs:
+        title: Unsafe Go Routine Variables
+        body: Example tenet that finds unsafe variables in goroutines.
+      codelingo/review:
+        comment: The variable {{ identName }} should be passed in as arguments to go-routines to avoid race conditions.
+    query: |
+      import codelingo/ast/go
+      go.go_stmt(depth = any):
+        go.block_stmt(depth = any):
+          @review comment
+          go.ident(depth = any):
+            name as identName
+            type # Only idents referring to variables have a type property
+          exclude:
+            go.assign_stmt(depth = any):
+              go.lhs:
+                go.ident:
+                  name == identName
+        exclude:
+          go.names(depth = any):
+            go.ident(depth = any):
+              name == identName

--- a/tenets/codelingo/go/unsafe-go-routine-variables/expected.json
+++ b/tenets/codelingo/go/unsafe-go-routine-variables/expected.json
@@ -1,0 +1,20 @@
+[
+  {
+   "Comment": "The variable close should be passed in as arguments to go-routines to avoid race conditions.",
+   "Filename": "test.go",
+   "Line": 14,
+   "Snippet": "\tintc := make(chan int)\n\tgo func() {\n\t\tdefer close(intc)\n\t}()\n\treturn intc"
+  },
+  {
+   "Comment": "The variable intc should be passed in as arguments to go-routines to avoid race conditions.",
+   "Filename": "test.go",
+   "Line": 14,
+   "Snippet": "\tintc := make(chan int)\n\tgo func() {\n\t\tdefer close(intc)\n\t}()\n\treturn intc"
+  },
+  {
+   "Comment": "The variable close should be passed in as arguments to go-routines to avoid race conditions.",
+   "Filename": "test.go",
+   "Line": 6,
+   "Snippet": "\tintc := make(chan int)\n\tgo func(intc chan\u003c- int) {\n\t\tdefer close(intc)\n\t}(intc)\n\treturn intc"
+  }
+ ]

--- a/tenets/codelingo/go/unsafe-go-routine-variables/test.go
+++ b/tenets/codelingo/go/unsafe-go-routine-variables/test.go
@@ -1,0 +1,17 @@
+package main
+
+func safe() <-chan int {
+	intc := make(chan int)
+	go func(intc chan<- int) {
+		defer close(intc)
+	}(intc)
+	return intc
+}
+
+func unsafe() <-chan int { // ISSUE
+	intc := make(chan int)
+	go func() {
+		defer close(intc)
+	}()
+	return intc
+}


### PR DESCRIPTION
Move tenet from the platform to this repo, as it applies generally.
Add variable name to the comment so the user can quickly identify the bug.

Currently gets false positives for the `close` ident, since we can't easily distinguish variable declarations from other identifiers. This can be solved by changing the meaning of `type` to assert that the `type` property exists https://trello.com/c/zPq9NzOt/453-has-property-assertion.