### PR TITLE
Fix avoid-renaming-imports.

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -44,7 +44,7 @@ codelingo:
     version: 0.0.0
     tenets:
       avoid-renaming-imports:
-        hasIssues: true
+        hasIssues: false
       context-first-arg:
         hasIssues: false
       do-not-discard-errors:

--- a/tenets/codelingo/code-review-comments/avoid-renaming-imports/codelingo.yaml
+++ b/tenets/codelingo/code-review-comments/avoid-renaming-imports/codelingo.yaml
@@ -1,11 +1,17 @@
 funcs:
-  - name: importNamesAreDifferent
+  - name: importNamesEqual
     type: asserter
     body: |
       function(a, b) {
         var aSplit = a.toLowerCase().split("/")
         var bSplit = b.toLowerCase().split("/")
-        return a[a.length - 1] !== b[b.length - 1]
+        return a[a.length - 1] === b[b.length - 1]
+      }
+  - name: neq
+    type: asserter
+    body: |
+      function(a, b) {
+        return a !== b
       }
 tenets:
   - name: avoid-renaming-imports
@@ -25,13 +31,17 @@ tenets:
 
       go.gen_decl(depth = any):
         @review comment
-        go.import_spec(depth = 0:2):
+        go.import_spec:
+          start_offset as soOne # stand in for UID
           go.ident: # Ident is the rename and absent if not named
             name as importName
             name != "_"
           go.basic_lit: # Basic_lit is the "import/path"
             value as importOne
-        go.import_spec:
-          go.basic_lit:
-            value as importTwo
-        importNamesAreDifferent(importOne, importTwo)
+        exclude:
+          go.import_spec:
+            start_offset as soTwo
+            neq(soOne, soTwo)
+            go.basic_lit:
+              value as importTwo
+              importNamesEqual(importOne, importTwo)

--- a/tenets/codelingo/code-review-comments/avoid-renaming-imports/example2.go
+++ b/tenets/codelingo/code-review-comments/avoid-renaming-imports/example2.go
@@ -1,0 +1,12 @@
+// Package main is an example package
+package main
+
+import (
+	badfmt "fmt"
+	rando "math/rand"
+	_ "os"
+)
+
+func main() {
+	badfmt.Println("Hello, playground", rando.New())
+}

--- a/tenets/codelingo/code-review-comments/avoid-renaming-imports/expected.json
+++ b/tenets/codelingo/code-review-comments/avoid-renaming-imports/expected.json
@@ -1,32 +1,20 @@
 [
   {
-   "Comment": "Avoid renaming imports except to avoid a name collision; good package names\nshould not require renaming. In the event of collision, prefer to rename the\nmost local or project-specific import.\n",
-   "Filename": "code-review-comments/avoid-renaming-imports/example.go",
+   "Comment": "This import is renamed to `badfmt` but this is a bad practice. \nImport without specifying a new name.\n",
+   "Filename": "example.go",
    "Line": 5,
-   "Snippet": "import (\n\tbadfmt \"fmt\"\n\totherrand \"math/rand\"\n    \"path/to/different/rand\"\n\t_ \"os\""
+   "Snippet": "\nimport (\n\tbadfmt \"fmt\"\n\totherrand \"math/rand\"\n\t_ \"os\""
   },
   {
-   "Comment": "Avoid renaming imports except to avoid a name collision; good package names\nshould not require renaming. In the event of collision, prefer to rename the\nmost local or project-specific import.\n",
-   "Filename": "code-review-comments/avoid-renaming-imports/example.go",
-   "Line": 4,
-   "Snippet": "\nimport (\n\tbadfmt \"fmt\"\n\totherrand \"math/rand\"\n    \"path/to/different/rand\""
-  },
-  {
-   "Comment": "Avoid renaming imports except to avoid a name collision; good package names\nshould not require renaming. In the event of collision, prefer to rename the\nmost local or project-specific import.\n",
-   "Filename": "code-review-comments/avoid-renaming-imports/example.go",
-   "Line": 4,
-   "Snippet": "\nimport (\n\tbadfmt \"fmt\"\n\totherrand \"math/rand\"\n    \"path/to/different/rand\""
-  },
-  {
-   "Comment": "Avoid renaming imports except to avoid a name collision; good package names\nshould not require renaming. In the event of collision, prefer to rename the\nmost local or project-specific import.\n",
-   "Filename": "code-review-comments/avoid-renaming-imports/example.go",
+   "Comment": "This import is renamed to `badfmt` but this is a bad practice. \nImport without specifying a new name.\n",
+   "Filename": "example2.go",
    "Line": 5,
-   "Snippet": "import (\n\tbadfmt \"fmt\"\n\totherrand \"math/rand\"\n    \"path/to/different/rand\"\n\t_ \"os\""
+   "Snippet": "\nimport (\n\tbadfmt \"fmt\"\n\trando \"math/rand\"\n\t_ \"os\""
   },
   {
-   "Comment": "Avoid renaming imports except to avoid a name collision; good package names\nshould not require renaming. In the event of collision, prefer to rename the\nmost local or project-specific import.\n",
-   "Filename": "code-review-comments/avoid-renaming-imports/example.go",
-   "Line": 4,
-   "Snippet": "\nimport (\n\tbadfmt \"fmt\"\n\totherrand \"math/rand\"\n    \"path/to/different/rand\""
+   "Comment": "This import is renamed to `rando` but this is a bad practice. \nImport without specifying a new name.\n",
+   "Filename": "example2.go",
+   "Line": 6,
+   "Snippet": "import (\n\tbadfmt \"fmt\"\n\trando \"math/rand\"\n\t_ \"os\"\n)"
   }
  ]

--- a/tenets/codelingo/code-review-comments/avoid-renaming-imports/issues.yaml
+++ b/tenets/codelingo/code-review-comments/avoid-renaming-imports/issues.yaml
@@ -1,2 +1,0 @@
-issues:
-  - https://github.com/codelingo/codelingo/issues/212


### PR DESCRIPTION
If there is a renamed import, assert that there is no other import with the same ending, rather than asserting that there is an import without the same ending. Make sure the two import statements are not the same.