### PR TITLE
Move empty function comment to its own tenet.

### DIFF
--- a/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml
+++ b/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml
@@ -61,23 +61,4 @@ tenets:
           name as funcName
           public == "true"
           isValid(commText, funcName)
-
-tenets:
-  - name: comment-first-word-when-empty
-    flows:
-      codelingo/review:
-        comment: |
-          The first sentence should be a one-sentence summary that starts with the name ({{funcName}}) being declared.
-      codelingo/rewrite:
-        place: holder
-    query: |
-      import codelingo/ast/go
-
-      @review comment
-      @rewrite --prepend --line "// {{funcName}} is a function."
-      go.func_decl(depth = any):
-        exclude:
-          go.comment_group
-        go.ident:
-          name as funcName
-          public == "true"
+          

--- a/tenets/codelingo/effective-go/comment-first-word-when-empty/codelingo.yaml
+++ b/tenets/codelingo/effective-go/comment-first-word-when-empty/codelingo.yaml
@@ -1,0 +1,19 @@
+tenets:
+  - name: comment-first-word-when-empty
+    flows:
+      codelingo/review:
+        comment: |
+          The first sentence should be a one-sentence summary that starts with the name ({{funcName}}) being declared.
+      codelingo/rewrite:
+        place: holder
+    query: |
+      import codelingo/ast/go
+
+      @review comment
+      @rewrite --prepend --line "// {{funcName}} is a function."
+      go.func_decl(depth = any):
+        exclude:
+          go.comment_group
+        go.ident:
+          name as funcName
+          public == "true"

--- a/tenets/codelingo/effective-go/comment-first-word-when-empty/example.go
+++ b/tenets/codelingo/effective-go/comment-first-word-when-empty/example.go
@@ -1,0 +1,3 @@
+package main
+
+func Unnamed() {}

--- a/tenets/codelingo/effective-go/comment-first-word-when-empty/expected.json
+++ b/tenets/codelingo/effective-go/comment-first-word-when-empty/expected.json
@@ -1,0 +1,8 @@
+[
+  {
+   "Comment": "The first sentence should be a one-sentence summary that starts with the name (Unnamed) being declared.\n",
+   "Filename": "example.go",
+   "Line": 3,
+   "Snippet": "package main\n\nfunc Unnamed() {}\n"
+  }
+ ]


### PR DESCRIPTION
Though these two tenets address the same rule they are used in a different way, and you can't import two tenets in the same codelingo.yaml file separately. The `comment-first-word-as-subject` tenet is mature, and produces reasonably good rewrite output on a first pass and the `comment-first-word-when-empty` tenet is going to be more useful interactively.