### PR TITLE
Fix context-first-arg tenet to only look at field lists related to functions

### DIFF
--- a/tenets/codelingo/code-review-comments/context-first-arg/codelingo.yaml
+++ b/tenets/codelingo/code-review-comments/context-first-arg/codelingo.yaml
@@ -16,16 +16,16 @@ tenets:
           Consider moving Context to the front.
     query: |
       import codelingo/ast/go
-      
-      go.field_list(depth = any):
-        sibling_order == 0
-        go.field:
-          sibling_order > 0
-          go.names:
-            go.ident
-          @review comment
-          go.selector_expr:
-            go.ident:
-              name == "context"
-            go.ident:
-              name == "Context"
+      go.func_type(depth = any):
+        go.field_list:
+          sibling_order == 0
+          go.field:
+            sibling_order > 0
+            go.names:
+              go.ident
+            @review comment
+            go.selector_expr:
+              go.ident:
+                name == "context"
+              go.ident:
+                name == "Context"

--- a/tenets/codelingo/code-review-comments/context-first-arg/example.go
+++ b/tenets/codelingo/code-review-comments/context-first-arg/example.go
@@ -8,18 +8,17 @@ func F(ctx context.Context, a int)               {}
 func G(b int, ctx context.Context, a int)        {}
 func H(c int, b int, ctx context.Context, a int) {}
 
-
 // Don't catch them in structs
 type IsTypeOfParams struct {
-    // Value that needs to be resolve.
-    // Use this to decide which GraphQLObject this value maps to.
-    Value interface{}
+	// Value that needs to be resolve.
+	// Use this to decide which GraphQLObject this value maps to.
+	Value interface{}
 
-    // Info is a collection of information about the current execution state.
-    Info ResolveInfo
+	// Info is a collection of information about the current execution state.
+	Info ResolveInfo
 
-    // Context argument is a context value that is provided to every resolve function within an execution.
-    // It is commonly
-    // used to represent an authenticated user, or request-specific caches.
-    Context context.Context
+	// Context argument is a context value that is provided to every resolve function within an execution.
+	// It is commonly
+	// used to represent an authenticated user, or request-specific caches.
+	Context context.Context
 }

--- a/tenets/codelingo/code-review-comments/context-first-arg/example.go
+++ b/tenets/codelingo/code-review-comments/context-first-arg/example.go
@@ -1,18 +1,25 @@
-//Package main is an example package
 package main
 
 import (
-    "fmt"
+	"fmt"
 )
 
-func aFunc(ctx context.Context, a int) {
-    
-}
+func F(ctx context.Context, a int)               {}
+func G(b int, ctx context.Context, a int)        {}
+func H(c int, b int, ctx context.Context, a int) {}
 
-func bFunc(a, b int) (con context.Context) {
 
-}
+// Don't catch them in structs
+type IsTypeOfParams struct {
+    // Value that needs to be resolve.
+    // Use this to decide which GraphQLObject this value maps to.
+    Value interface{}
 
-func cFunc(c int, b int, ctx context.Context, a int) {
+    // Info is a collection of information about the current execution state.
+    Info ResolveInfo
 
+    // Context argument is a context value that is provided to every resolve function within an execution.
+    // It is commonly
+    // used to represent an authenticated user, or request-specific caches.
+    Context context.Context
 }

--- a/tenets/codelingo/code-review-comments/context-first-arg/example.go
+++ b/tenets/codelingo/code-review-comments/context-first-arg/example.go
@@ -4,9 +4,17 @@ import (
 	"fmt"
 )
 
-func F(ctx context.Context, a int)               {}
-func G(b int, ctx context.Context, a int)        {}
-func H(c int, b int, ctx context.Context, a int) {}
+func aFunc(ctx context.Context, a int) {
+	// Do something
+}
+
+func bFunc(b int, ctx context.Context, a int) {
+	// Do something
+}
+
+func cFunc(c int, b int, ctx context.Context, a int) {
+	// Do something
+}
 
 // Don't catch them in structs
 type IsTypeOfParams struct {


### PR DESCRIPTION
Was getting false positives from contexts in other structures. This should fix it