### PR TITLE
Fix blank identifier false positive

### DIFF
--- a/tenets/codelingo/effective-go/underscores-in-name/codelingo.yaml
+++ b/tenets/codelingo/effective-go/underscores-in-name/codelingo.yaml
@@ -3,6 +3,9 @@ funcs:
     type: asserter
     body: |
       function(name) {
+        if (name.length === 1) {
+          return false
+        }
         return name.indexOf("_") !== -1
       }
   - name: isNotProto


### PR DESCRIPTION
Ignore names that have a length of one to eliminate false positives from blank identifiers. Will update this tenet with a new expected.json file and additional test cases ASAP