### PR TITLE
Add null check to JS function

### DIFF
--- a/tenets/codelingo/cockroachdb/fmt-verbs/codelingo.yaml
+++ b/tenets/codelingo/cockroachdb/fmt-verbs/codelingo.yaml
@@ -5,6 +5,7 @@ funcs:
       function (str, order) {
         order--
         var matches = str.match(/%[A-Za-z]/g)
+        if (matches === null) return false
         if (matches.length <= order) return false
         var result = matches[order]
         return result === "%v"


### PR DESCRIPTION
Would fail when doing a length check on a null reference. Early return to solve.