### PR TITLE
Add original file line to comment dump and fix (most) tests

### DIFF
--- a/flows/codelingo/rewrite/rewrite/writer.go
+++ b/flows/codelingo/rewrite/rewrite/writer.go
@@ -207,7 +207,7 @@ func newFileSRC(ctx *cli.Context, hunk *rewriterpc.Hunk, fileSRC []byte) ([]byte
 			if updatedLine != commentedLine {
 				c = &comment{
 					Content:  string(commentedLine),
-					Original: string(fileSRC[lineNumber+1]),
+					Original: string(fileSRC),
 					Line:     lineNumber + 1,
 				}
 				break

--- a/flows/codelingo/rewrite/rewrite/writer.go
+++ b/flows/codelingo/rewrite/rewrite/writer.go
@@ -204,7 +204,6 @@ func newFileSRC(ctx *cli.Context, hunk *rewriterpc.Hunk, fileSRC []byte) ([]byte
 			}
 
 			commentedLine := commentedLines[lineNumber]
-			//originalLine := parts[lineNumber]
 			if updatedLine != commentedLine {
 				c = &comment{
 					Content:  string(commentedLine),

--- a/flows/codelingo/rewrite/rewrite/writer.go
+++ b/flows/codelingo/rewrite/rewrite/writer.go
@@ -182,6 +182,7 @@ type comment struct {
 
 func newFileSRC(ctx *cli.Context, hunk *rewriterpc.Hunk, fileSRC []byte) ([]byte, *comment, error) {
 	parts := splitSRC(hunk, fileSRC)
+	fileSRClines := strings.Split(string(fileSRC), "\n")
 
 	rewrittenFile, err := rewriteFile(ctx, fileSRC, []byte(hunk.SRC), parts, hunk)
 	if err != nil {
@@ -207,7 +208,7 @@ func newFileSRC(ctx *cli.Context, hunk *rewriterpc.Hunk, fileSRC []byte) ([]byte
 			if updatedLine != commentedLine {
 				c = &comment{
 					Content:  string(commentedLine),
-					Original: string(fileSRC),
+					Original: fileSRClines[lineNumber],
 					Line:     lineNumber + 1,
 				}
 				break

--- a/flows/codelingo/rewrite/rewrite/writer.go
+++ b/flows/codelingo/rewrite/rewrite/writer.go
@@ -203,11 +203,11 @@ func newFileSRC(ctx *cli.Context, hunk *rewriterpc.Hunk, fileSRC []byte) ([]byte
 			}
 
 			commentedLine := commentedLines[lineNumber]
-			originalLine := fileSRC[lineNumber]
+			//originalLine := parts[lineNumber]
 			if updatedLine != commentedLine {
 				c = &comment{
 					Content:  string(commentedLine),
-					Original: string(originalLine),
+					Original: string(fileSRC[lineNumber+1]),
 					Line:     lineNumber + 1,
 				}
 				break

--- a/flows/codelingo/rewrite/rewrite/writer.go
+++ b/flows/codelingo/rewrite/rewrite/writer.go
@@ -173,7 +173,8 @@ func splitSRC(hunk *rewriterpc.Hunk, fileSRC []byte) partitionedFile {
 }
 
 type comment struct {
-	Content string `json:"content"`
+	Content  string `json:"content"`
+	Original string `json:"original"`
 	// TODO: comments should span multiple lines, but github doesn't allow that https://github.community/t5/How-to-use-Git-and-GitHub/Feature-request-Multiline-reviews-in-pull-requests/m-p/9850#M3225
 	Line int    `json:"line"`
 	Path string `json:"path"`
@@ -202,10 +203,12 @@ func newFileSRC(ctx *cli.Context, hunk *rewriterpc.Hunk, fileSRC []byte) ([]byte
 			}
 
 			commentedLine := commentedLines[lineNumber]
+			originalLine := fileSRC[lineNumber]
 			if updatedLine != commentedLine {
 				c = &comment{
-					Content: string(commentedLine),
-					Line:    lineNumber + 1,
+					Content:  string(commentedLine),
+					Original: string(originalLine),
+					Line:     lineNumber + 1,
 				}
 				break
 			}

--- a/flows/codelingo/rewrite/rewrite/writer_test.go
+++ b/flows/codelingo/rewrite/rewrite/writer_test.go
@@ -103,8 +103,9 @@ var testData = []struct {
 	{
 		decOpts: "rewrite \"<NEW CODE>\"",
 		comment: &comment{
-			line:    2,
-			content: "func <ALT CODE>() {",
+			line:     2,
+			content:  "func <ALT CODE>() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -116,8 +117,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite name",
 		comment: &comment{
-			line:    2,
-			content: "func <ALT CODE>() {",
+			line:     2,
+			content:  "func <ALT CODE>() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -129,8 +131,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite --replace name",
 		comment: &comment{
-			line:    2,
-			content: "func <ALT CODE>() {",
+			line:     2,
+			content:  "func <ALT CODE>() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -142,8 +145,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite --replace --start-to-end-offset name",
 		comment: &comment{
-			line:    2,
-			content: "func <ALT CODE>() {",
+			line:     2,
+			content:  "func <ALT CODE>() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -155,8 +159,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite --start-to-end-offset name",
 		comment: &comment{
-			line:    2,
-			content: "func <ALT CODE>() {",
+			line:     2,
+			content:  "func <ALT CODE>() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -168,8 +173,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite --start-offset name",
 		comment: &comment{
-			line:    2,
-			content: "func <ALT CODE>ain() {",
+			line:     2,
+			content:  "func <ALT CODE>ain() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -181,8 +187,9 @@ func <NEW CODE>ain() {
 	}, {
 		decOpts: "rewrite --line name",
 		comment: &comment{
-			line:    2,
-			content: "<ALT CODE>",
+			line:     2,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -194,8 +201,9 @@ package test
 	}, {
 		decOpts: "rewrite --start-offset --line name",
 		comment: &comment{
-			line:    2,
-			content: "<ALT CODE>",
+			line:     2,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -207,8 +215,9 @@ package test
 	}, {
 		decOpts: "rewrite --end-offset --line name",
 		comment: &comment{
-			line:    2,
-			content: "<ALT CODE>",
+			line:     2,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -220,8 +229,9 @@ package test
 	}, {
 		decOpts: "rewrite --start-to-end-offset --prepend name",
 		comment: &comment{
-			line:    2,
-			content: "func <ALT CODE>main() {",
+			line:     2,
+			content:  "func <ALT CODE>main() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -233,8 +243,9 @@ func <NEW CODE>main() {
 	}, {
 		decOpts: "rewrite --start-offset --prepend name",
 		comment: &comment{
-			line:    2,
-			content: "func <ALT CODE>main() {",
+			line:     2,
+			content:  "func <ALT CODE>main() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -246,8 +257,9 @@ func <NEW CODE>main() {
 	}, {
 		decOpts: "rewrite --prepend name",
 		comment: &comment{
-			line:    2,
-			content: "func <ALT CODE>main() {",
+			line:     2,
+			content:  "func <ALT CODE>main() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -259,8 +271,9 @@ func <NEW CODE>main() {
 	}, {
 		decOpts: "rewrite --end-offset --prepend name",
 		comment: &comment{
-			line:    2,
-			content: "func mai<ALT CODE>n() {",
+			line:     2,
+			content:  "func mai<ALT CODE>n() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -272,8 +285,9 @@ func mai<NEW CODE>n() {
 	}, {
 		decOpts: "rewrite --prepend --line name",
 		comment: &comment{
-			line:    2,
-			content: "<ALT CODE>",
+			line:     2,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -286,8 +300,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --start-to-end-offset --prepend --line name",
 		comment: &comment{
-			line:    2,
-			content: "<ALT CODE>",
+			line:     2,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -300,8 +315,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --start-offset --prepend --line name",
 		comment: &comment{
-			line:    2,
-			content: "<ALT CODE>",
+			line:     2,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -314,8 +330,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --end-offset --prepend --line name",
 		comment: &comment{
-			line:    2,
-			content: "<ALT CODE>",
+			line:     2,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -328,8 +345,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --append name",
 		comment: &comment{
-			line:    2,
-			content: "func main<ALT CODE>() {",
+			line:     2,
+			content:  "func main<ALT CODE>() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -341,8 +359,9 @@ func main<NEW CODE>() {
 	}, {
 		decOpts: "rewrite --start-to-end-offset --append name",
 		comment: &comment{
-			line:    2,
-			content: "func main<ALT CODE>() {",
+			line:     2,
+			content:  "func main<ALT CODE>() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -354,8 +373,9 @@ func main<NEW CODE>() {
 	}, {
 		decOpts: "rewrite --start-offset --append name",
 		comment: &comment{
-			line:    2,
-			content: "func m<ALT CODE>ain() {",
+			line:     2,
+			content:  "func m<ALT CODE>ain() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -367,8 +387,9 @@ func m<NEW CODE>ain() {
 	}, {
 		decOpts: "rewrite --end-offset --append name",
 		comment: &comment{
-			line:    2,
-			content: "func main<ALT CODE>() {",
+			line:     2,
+			content:  "func main<ALT CODE>() {",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -380,8 +401,9 @@ func main<NEW CODE>() {
 	}, {
 		decOpts: "rewrite --append --line name",
 		comment: &comment{
-			line:    3,
-			content: "<ALT CODE>",
+			line:     3,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -394,8 +416,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --start-to-end-offset --append --line name",
 		comment: &comment{
-			line:    3,
-			content: "<ALT CODE>",
+			line:     3,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -408,8 +431,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --end-offset --append --line name",
 		comment: &comment{
-			line:    3,
-			content: "<ALT CODE>",
+			line:     3,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -422,8 +446,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --start-offset --append --line name",
 		comment: &comment{
-			line:    3,
-			content: "<ALT CODE>",
+			line:     3,
+			content:  "<ALT CODE>",
+			original: "func main() {",
 		},
 		newSRC: []byte(`
 package test

--- a/flows/codelingo/rewrite/rewrite/writer_test.go
+++ b/flows/codelingo/rewrite/rewrite/writer_test.go
@@ -87,7 +87,7 @@ func (s *cmdSuite) TestNewFileSRC(c *gc.C) {
 	}
 }
 
-var oldSRC string = `
+var oldSRC = `
 package test
 
 func main() {
@@ -103,9 +103,9 @@ var testData = []struct {
 	{
 		decOpts: "rewrite \"<NEW CODE>\"",
 		comment: &comment{
-			line:     2,
-			content:  "func <ALT CODE>() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func <ALT CODE>() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -117,9 +117,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite name",
 		comment: &comment{
-			line:     2,
-			content:  "func <ALT CODE>() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func <ALT CODE>() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -131,9 +131,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite --replace name",
 		comment: &comment{
-			line:     2,
-			content:  "func <ALT CODE>() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func <ALT CODE>() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -145,9 +145,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite --replace --start-to-end-offset name",
 		comment: &comment{
-			line:     2,
-			content:  "func <ALT CODE>() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func <ALT CODE>() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -159,9 +159,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite --start-to-end-offset name",
 		comment: &comment{
-			line:     2,
-			content:  "func <ALT CODE>() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func <ALT CODE>() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -173,9 +173,9 @@ func <NEW CODE>() {
 	}, {
 		decOpts: "rewrite --start-offset name",
 		comment: &comment{
-			line:     2,
-			content:  "func <ALT CODE>ain() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func <ALT CODE>ain() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -187,9 +187,9 @@ func <NEW CODE>ain() {
 	}, {
 		decOpts: "rewrite --line name",
 		comment: &comment{
-			line:     2,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     2,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -201,9 +201,9 @@ package test
 	}, {
 		decOpts: "rewrite --start-offset --line name",
 		comment: &comment{
-			line:     2,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     2,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -215,9 +215,9 @@ package test
 	}, {
 		decOpts: "rewrite --end-offset --line name",
 		comment: &comment{
-			line:     2,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     2,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -229,9 +229,9 @@ package test
 	}, {
 		decOpts: "rewrite --start-to-end-offset --prepend name",
 		comment: &comment{
-			line:     2,
-			content:  "func <ALT CODE>main() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func <ALT CODE>main() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -243,9 +243,9 @@ func <NEW CODE>main() {
 	}, {
 		decOpts: "rewrite --start-offset --prepend name",
 		comment: &comment{
-			line:     2,
-			content:  "func <ALT CODE>main() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func <ALT CODE>main() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -257,9 +257,9 @@ func <NEW CODE>main() {
 	}, {
 		decOpts: "rewrite --prepend name",
 		comment: &comment{
-			line:     2,
-			content:  "func <ALT CODE>main() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func <ALT CODE>main() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -271,9 +271,9 @@ func <NEW CODE>main() {
 	}, {
 		decOpts: "rewrite --end-offset --prepend name",
 		comment: &comment{
-			line:     2,
-			content:  "func mai<ALT CODE>n() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func mai<ALT CODE>n() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -285,9 +285,9 @@ func mai<NEW CODE>n() {
 	}, {
 		decOpts: "rewrite --prepend --line name",
 		comment: &comment{
-			line:     2,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     2,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -300,9 +300,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --start-to-end-offset --prepend --line name",
 		comment: &comment{
-			line:     2,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     2,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -315,9 +315,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --start-offset --prepend --line name",
 		comment: &comment{
-			line:     2,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     2,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -330,9 +330,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --end-offset --prepend --line name",
 		comment: &comment{
-			line:     2,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     2,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -345,9 +345,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --append name",
 		comment: &comment{
-			line:     2,
-			content:  "func main<ALT CODE>() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func main<ALT CODE>() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -359,9 +359,9 @@ func main<NEW CODE>() {
 	}, {
 		decOpts: "rewrite --start-to-end-offset --append name",
 		comment: &comment{
-			line:     2,
-			content:  "func main<ALT CODE>() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func main<ALT CODE>() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -373,9 +373,9 @@ func main<NEW CODE>() {
 	}, {
 		decOpts: "rewrite --start-offset --append name",
 		comment: &comment{
-			line:     2,
-			content:  "func m<ALT CODE>ain() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func m<ALT CODE>ain() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -387,9 +387,9 @@ func m<NEW CODE>ain() {
 	}, {
 		decOpts: "rewrite --end-offset --append name",
 		comment: &comment{
-			line:     2,
-			content:  "func main<ALT CODE>() {",
-			original: "func main() {",
+			Line:     2,
+			Content:  "func main<ALT CODE>() {",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -401,9 +401,9 @@ func main<NEW CODE>() {
 	}, {
 		decOpts: "rewrite --append --line name",
 		comment: &comment{
-			line:     3,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     3,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -416,9 +416,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --start-to-end-offset --append --line name",
 		comment: &comment{
-			line:     3,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     3,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -431,9 +431,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --end-offset --append --line name",
 		comment: &comment{
-			line:     3,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     3,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test
@@ -446,9 +446,9 @@ func main() {
 	}, {
 		decOpts: "rewrite --start-offset --append --line name",
 		comment: &comment{
-			line:     3,
-			content:  "<ALT CODE>",
-			original: "func main() {",
+			Line:     3,
+			Content:  "<ALT CODE>",
+			Original: "func main() {",
 		},
 		newSRC: []byte(`
 package test


### PR DESCRIPTION
Added "original" line data to the comment struct so it can be used when automating rewrite PR comments. This will save having to recalculate diff positions and extract the line data from the diff. Also fixed capitalisation on comment test structs as all tests were failing on this.

The last couple of tests are still failing in writer_test.go (the ones with `Line: 3`). Not sure why but they were failing before I touched the code. We should go back and get those passing.