### PR TITLE
Exclude tests from comment-first-word-as-subject.

### DIFF
--- a/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml
+++ b/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml
@@ -257,15 +257,18 @@ tenets:
     query: |
       import codelingo/ast/go
 
-      # Only look at exported functions
-      go.func_decl(depth = any):
-        go.comment_group:
-          @review comment
-          @rewrite --replace "{{fixComment(commText, funcName)}}"
-          go.comment:
-            sibling_order == 0
-            text as commText
-        go.ident:
-          public == "true"
-          name as funcName
-          isValid(commText, funcName)
+      go.file(depth = any):
+        exclude:
+          filename as filename
+          regexp(/*_test.go/, filename)
+        go.func_decl(depth = any):
+          go.comment_group:
+            @review comment
+            @rewrite --replace "{{fixComment(commText, funcName)}}"
+            go.comment:
+              sibling_order == 0
+              text as commText
+          go.ident:
+            public == "true"
+            name as funcName
+            isValid(commText, funcName)

--- a/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml
+++ b/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml
@@ -1,4 +1,16 @@
 funcs:
+  - name: isNotATestFile
+    type: asserter
+    body: |
+      function(filename) {
+        // ES5 workaround
+        // TODO: don't use ES5
+        String.prototype.endsWith = String.prototype.endsWith || function(suffix) {
+          return this.indexOf(suffix, this.length - suffix.length) >= 0;
+        };
+
+        return !filename.endsWith("_test.go")
+      }
   - name: isValid
     type: asserter
     body: |
@@ -258,9 +270,8 @@ tenets:
       import codelingo/ast/go
 
       go.file(depth = any):
-        exclude:
-          filename as filename
-          regexp(/*_test.go/, filename)
+        filename as filename
+        isNotATestFile(filename)
         go.func_decl(depth = any):
           go.comment_group:
             @review comment

--- a/tenets/codelingo/effective-go/comment-first-word-as-subject/example_test.go
+++ b/tenets/codelingo/effective-go/comment-first-word-as-subject/example_test.go
@@ -1,0 +1,48 @@
+// Package main used for testing the tenet
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("Hello, playground")
+	// This comment not on a func decl
+}
+
+/* foo is the first word
+ */
+func foo() {}
+
+
+/* Foo is the first word
+ */
+func Foo() {}
+
+/* This func comment should begin with 'bar'
+ */
+func bar() {}
+
+/* This func comment should begin with 'Bar'
+ */
+func Bar() {}
+
+// This func comment should begin with 'baz'
+// and we should not worry about this line
+func baz() {}
+
+// This func comment should begin with 'Baz'
+// and we should not worry about this line
+func Baz() {}
+
+// This is called by a xyz
+func qux() {}
+
+// This is called by a xyz
+func Qux() {}
+
+// The quux will handle xyz
+func quux() {}
+
+// The Quux will handle xyz
+func Quux() {}

--- a/tenets/codelingo/effective-go/comment-first-word-as-subject/expected.json
+++ b/tenets/codelingo/effective-go/comment-first-word-as-subject/expected.json
@@ -1,26 +1,26 @@
 [
   {
-   "Comment": "The first sentence should be a one-sentence summary that starts with the name (bar) being declared.\n",
+   "Comment": "Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name (Baz) being declared.\nFrom [effective go](https://golang.org/doc/effective_go.html#commentary).\n",
    "Filename": "example.go",
-   "Line": 17,
-   "Snippet": "func foo() {}\n\n/* This func comment should begin with 'bar'\n */\nfunc bar() {}\n"
+   "Line": 34,
+   "Snippet": "func baz() {}\n\n// This func comment should begin with 'Baz'\n// and we should not worry about this line\nfunc Baz() {}"
   },
   {
-   "Comment": "The first sentence should be a one-sentence summary that starts with the name (qux) being declared.\n",
+   "Comment": "Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name (Quux) being declared.\nFrom [effective go](https://golang.org/doc/effective_go.html#commentary).\n",
    "Filename": "example.go",
-   "Line": 25,
-   "Snippet": "func baz() {}\n\n// This is called by a xyz\nfunc qux() {}\n"
+   "Line": 47,
+   "Snippet": "func quux() {}\n\n// The Quux will handle xyz\nfunc Quux() {}"
   },
   {
-   "Comment": "The first sentence should be a one-sentence summary that starts with the name (quux) being declared.\n",
+   "Comment": "Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name (Qux) being declared.\nFrom [effective go](https://golang.org/doc/effective_go.html#commentary).\n",
    "Filename": "example.go",
-   "Line": 28,
-   "Snippet": "func qux() {}\n\n// The quux will handle xyz\nfunc quux() {}"
+   "Line": 41,
+   "Snippet": "func qux() {}\n\n// This is called by a xyz\nfunc Qux() {}\n"
   },
   {
-   "Comment": "The first sentence should be a one-sentence summary that starts with the name (baz) being declared.\n",
+   "Comment": "Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name (Bar) being declared.\nFrom [effective go](https://golang.org/doc/effective_go.html#commentary).\n",
    "Filename": "example.go",
-   "Line": 21,
-   "Snippet": "func bar() {}\n\n// This func comment should begin with 'baz'\n// and we should not worry about this line\nfunc baz() {}"
+   "Line": 26,
+   "Snippet": "func bar() {}\n\n/* This func comment should begin with 'Bar'\n */\nfunc Bar() {}\n"
   }
  ]


### PR DESCRIPTION
Users typically don't care about conventional comments on test functions. Nor does godoc, in fact. 