### PR TITLE
Return discarded errors

### DIFF
--- a/tenets/codelingo/code-review-comments/do-not-discard-errors/README.md
+++ b/tenets/codelingo/code-review-comments/do-not-discard-errors/README.md
@@ -1,3 +1,5 @@
 # do-not-discard-errors
 
+do-not-discard-errors finds and comments on discarded errors. It is different from [return-discarded-errors](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/code-review-comments/return-discarded-errors/codelingo.yaml) which rewrites and only checks inside functions.
+
 _by codelingo, part of their Code Review Comments bundle_

--- a/tenets/codelingo/code-review-comments/do-not-discard-errors/codelingo.yaml
+++ b/tenets/codelingo/code-review-comments/do-not-discard-errors/codelingo.yaml
@@ -13,15 +13,10 @@ tenets:
     query: |
       import codelingo/ast/go
 
-      # This tenet should also check if the error
-      # discarding is mentioned in a comment above.
-      # See issues.yaml for more info
-
       @review comment
-      go.block_stmt(depth = any):
-        go.assign_stmt(depth = any):
-          go.lhs:
-            go.ident:
-              name == "_"
-              type == "error"
-            
+      go.assign_stmt(depth = any):
+        go.lhs:
+          go.ident:
+            name == "_"
+            type == "error"
+

--- a/tenets/codelingo/code-review-comments/do-not-discard-errors/codelingo.yaml
+++ b/tenets/codelingo/code-review-comments/do-not-discard-errors/codelingo.yaml
@@ -9,7 +9,7 @@ tenets:
           in truly exceptional situations, panic.
       codelingo/review:
         comment: |
-          Do not discard errors using _ variables. If ignoring the err is intentional, add a justification in a comment.
+          Do not discard errors using _ variables.
     query: |
       import codelingo/ast/go
 

--- a/tenets/codelingo/code-review-comments/do-not-discard-errors/example.go
+++ b/tenets/codelingo/code-review-comments/do-not-discard-errors/example.go
@@ -8,11 +8,16 @@ import (
 
 func main() {
 	fmt.Println("Hello, playground")
-	a, _ := example()
+	a, _ := example() // ISSUE
 	fmt.Println(a)
 	fmt.Println(err)
 }
 
 func example() (int, error) {
 	return 1, errors.New("some error")
+}
+
+func trickyReturnExample() (int, *string, string, bool, error) {
+	i, _ := example() // ISSUE
+	return i, nil, "hello", true, nil
 }

--- a/tenets/codelingo/code-review-comments/do-not-discard-errors/example.go
+++ b/tenets/codelingo/code-review-comments/do-not-discard-errors/example.go
@@ -10,7 +10,21 @@ func main() {
 	fmt.Println("Hello, playground")
 	a, _ := example() // ISSUE
 	fmt.Println(a)
-	fmt.Println(err)
+}
+
+func passing() error {
+	_, err := example()
+	if err != nil {
+		return err
+	}
+
+	i, err := example()
+	if err != nil {
+		return err
+	}
+
+	_ = i
+	return nil
 }
 
 func example() (int, error) {

--- a/tenets/codelingo/code-review-comments/do-not-discard-errors/issues.yaml
+++ b/tenets/codelingo/code-review-comments/do-not-discard-errors/issues.yaml
@@ -1,2 +1,0 @@
-issues:
-  - https://github.com/codelingo/codelingo/issues/242

--- a/tenets/codelingo/code-review-comments/return-discarded-errors/README.md
+++ b/tenets/codelingo/code-review-comments/return-discarded-errors/README.md
@@ -1,3 +1,5 @@
-# do-not-discard-errors
+# return-discarded-errors
+
+return-discarded-errors finds errors that are discarded in functions and rewrites them so that they are returned instead. It is different from [do-not-discard-errors](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/code-review-comments/do-not-discard-errors/codelingo.yaml) which also checks the top level scope and does not rewrite.
 
 _by codelingo, part of their Code Review Comments bundle_

--- a/tenets/codelingo/code-review-comments/return-discarded-errors/README.md
+++ b/tenets/codelingo/code-review-comments/return-discarded-errors/README.md
@@ -1,0 +1,3 @@
+# do-not-discard-errors
+
+_by codelingo, part of their Code Review Comments bundle_

--- a/tenets/codelingo/code-review-comments/return-discarded-errors/codelingo.yaml
+++ b/tenets/codelingo/code-review-comments/return-discarded-errors/codelingo.yaml
@@ -1,0 +1,16 @@
+tenets:
+  - name: do-not-discard-errors
+    flows:
+      codelingo/rewrite:
+        comment: |
+          Do not discard errors using _ variables. If ignoring the err is intentional, add a justification in a comment.
+    query: |
+      import codelingo/ast/go
+
+      @review comment
+      go.assign_stmt(depth = any):
+        go.lhs:
+          go.ident:
+            name == "_"
+            type == "error"
+

--- a/tenets/codelingo/code-review-comments/return-discarded-errors/codelingo.yaml
+++ b/tenets/codelingo/code-review-comments/return-discarded-errors/codelingo.yaml
@@ -1,20 +1,29 @@
 tenets:
   - name: do-not-discard-errors
+    vars:
+      returnError: |
+        if err != nil {
+          return {{ zeroValues(args) }}
+        }
     flows:
       codelingo/review:
-        comment: Don't discard errors.
+        comment: Don't discard errors. {{ returnArgs }}
       codelingo/rewrite:
-        returnError: |
-          if err != nil {
-            return {{ zeroValues(argument) }}
-          }
+        place: holder
     query: |
       import codelingo/ast/go
 
       @review comment
       go.func_decl(depth = any):
+        go.func_type:
+          @place holder
+          go.field_list:
+            raw as args
+            sibling_order == 1
+        @rewrite --line --append "{{returnError}}"
         go.assign_stmt(depth = any):
           go.lhs:
+            @rewrite "err"
             go.ident:
               name == "_"
               type == "error"
@@ -22,7 +31,31 @@ funcs:
   - name: zeroValues
     type: resolver
     body: |
-      function (arguments) {
-        return a.concat(b);
+      function (args) {
+        if (args[0] == "(") {
+            args = args.slice(1)
+        }
+
+        if (args[args.length-1] == ")") {
+            args = args.slice(0, -1)
+        }
+
+        return args.split(", ").map(function(param){
+          switch(param) {
+            case "string":
+              return "\"\""
+            case "int", "int32", "int64", "float", "float32", "float64":
+              return "0"
+            case "bool":
+              return "false"
+            case "error":
+              return "err"
+            default:
+              if (param.indexOf("*") != -1) {
+                return "nil"
+              }
+              return param + "{}"
+          }
+        }).join(", ")
       }
 

--- a/tenets/codelingo/code-review-comments/return-discarded-errors/codelingo.yaml
+++ b/tenets/codelingo/code-review-comments/return-discarded-errors/codelingo.yaml
@@ -1,5 +1,5 @@
 tenets:
-  - name: do-not-discard-errors
+  - name: return-discarded-errors
     vars:
       returnError: |
         if err != nil {

--- a/tenets/codelingo/code-review-comments/return-discarded-errors/codelingo.yaml
+++ b/tenets/codelingo/code-review-comments/return-discarded-errors/codelingo.yaml
@@ -1,16 +1,28 @@
 tenets:
   - name: do-not-discard-errors
     flows:
+      codelingo/review:
+        comment: Don't discard errors.
       codelingo/rewrite:
-        comment: |
-          Do not discard errors using _ variables. If ignoring the err is intentional, add a justification in a comment.
+        returnError: |
+          if err != nil {
+            return {{ zeroValues(argument) }}
+          }
     query: |
       import codelingo/ast/go
 
       @review comment
-      go.assign_stmt(depth = any):
-        go.lhs:
-          go.ident:
-            name == "_"
-            type == "error"
+      go.func_decl(depth = any):
+        go.assign_stmt(depth = any):
+          go.lhs:
+            go.ident:
+              name == "_"
+              type == "error"
+funcs:
+  - name: zeroValues
+    type: resolver
+    body: |
+      function (arguments) {
+        return a.concat(b);
+      }
 

--- a/tenets/codelingo/code-review-comments/return-discarded-errors/example.go
+++ b/tenets/codelingo/code-review-comments/return-discarded-errors/example.go
@@ -22,3 +22,21 @@ func trickyReturnExample() (a, *a, int, *string, string, bool, error) {
 	i, _ := example() // ISSUE
 	return a{}, nil, i, nil, "hello", true, nil
 }
+
+func singleExample() error {
+	i, _ := example() // ISSUE
+	_ = i
+	return nil
+}
+
+func nonErrorDiscard() (int, error) {
+	_, err := example()
+	if err != nil {
+		return 0, err
+	}
+	return 0, nil
+}
+
+func (b *a) methodExample() (int, error) {
+	i, _ := example() // ISSUE
+	return i, nil

--- a/tenets/codelingo/code-review-comments/return-discarded-errors/example.go
+++ b/tenets/codelingo/code-review-comments/return-discarded-errors/example.go
@@ -12,6 +12,21 @@ func main() {
 	fmt.Println(a)
 }
 
+func passing() error {
+	_, err := example()
+	if err != nil {
+		return err
+	}
+
+	i, err := example()
+	if err != nil {
+		return err
+	}
+
+	_ = i
+	return nil
+}
+
 func example() (int, error) {
 	return 1, errors.New("some error")
 }

--- a/tenets/codelingo/code-review-comments/return-discarded-errors/example.go
+++ b/tenets/codelingo/code-review-comments/return-discarded-errors/example.go
@@ -1,0 +1,24 @@
+//Package main is an example package
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+func main() {
+	fmt.Println("Hello, playground")
+	a, _ := example() // ISSUE
+	fmt.Println(a)
+}
+
+func example() (int, error) {
+	return 1, errors.New("some error")
+}
+
+type a struct{}
+
+func trickyReturnExample() (a, *a, int, *string, string, bool, error) {
+	i, _ := example() // ISSUE
+	return a{}, nil, i, nil, "hello", true, nil
+}


### PR DESCRIPTION
Add a tenet that returns all discarded errors. Current rewrite returns a new set of arguments but doesn't ensure that error is assigned to, as that would require multiple rewrite decorators which is involved due to changing offsets. It also has to be run through gofmt after the rewrite.