### PR TITLE
Add PSR2 tenet to find and fix non-lowercase language constants

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -225,6 +225,8 @@ codelingo:
     tenets:
       elseif-not-else-if:
         hasIssues: false
+      lower-case-constant-values
+        hasIssues: false
     tags:
     - php
     - psr

--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -225,7 +225,7 @@ codelingo:
     tenets:
       elseif-not-else-if:
         hasIssues: false
-      lower-case-constant-values
+      lower-case-constant-values:
         hasIssues: false
     tags:
     - php

--- a/tenets/codelingo/psr2/lingo_bundle.yaml
+++ b/tenets/codelingo/psr2/lingo_bundle.yaml
@@ -2,6 +2,7 @@ description: Best practices for PHP from PSR-2.
 version: 0.0.0
 tenets:
   - elseif-not-else-if
+  - lower-case-constant-values
 tags:
   - php
   - psr

--- a/tenets/codelingo/psr2/lower-case-constant-values/.codelingoignore
+++ b/tenets/codelingo/psr2/lower-case-constant-values/.codelingoignore
@@ -1,0 +1,1 @@
+orig.php

--- a/tenets/codelingo/psr2/lower-case-constant-values/README.md
+++ b/tenets/codelingo/psr2/lower-case-constant-values/README.md
@@ -1,0 +1,3 @@
+# lower-case-constant-values 
+
+_by codelingo, part of their PSR-1 bundle_

--- a/tenets/codelingo/psr2/lower-case-constant-values/codelingo.yaml
+++ b/tenets/codelingo/psr2/lower-case-constant-values/codelingo.yaml
@@ -25,11 +25,9 @@ tenets:
     query: |
       import codelingo/ast/php
 
-      php.expr_assign(depth = any):
-        php.expr_variable
-        php.expr_constfetch:
-          @review comment
-          @rewrite --replace "{{fixCase(varName)}}"
-          php.name_fullyqualified:
-            name as varName
-            isIncorrectCase(varName)
+      php.expr_constfetch(depth = any):
+        @review comment
+        @rewrite --replace "{{fixCase(varName)}}"
+        php.name_fullyqualified:
+          name as varName
+          isIncorrectCase(varName)

--- a/tenets/codelingo/psr2/lower-case-constant-values/codelingo.yaml
+++ b/tenets/codelingo/psr2/lower-case-constant-values/codelingo.yaml
@@ -1,0 +1,35 @@
+funcs:
+  - name: isIncorrectCase
+    type: asserter
+    body: |
+      function(varName) {
+        var constants = ['true', 'false', 'null']
+
+        if (constants.indexOf(varName.toLowerCase()) !== -1) {
+          return varName !== varName.toLowerCase()
+        }
+        return false
+      }
+  - name: fixCase
+    type: resolver
+    body: |
+      function(varName) {
+        return varName.toLowerCase()
+      }
+tenets:
+  - name: lower-case-constant-values
+    flows:
+      codelingo/review:
+        comment: The PHP constants true, false, and null MUST be in lower case.
+      codelingo/rewrite:
+    query: |
+      import codelingo/ast/php
+
+      php.expr_assign(depth = any):
+        php.expr_variable
+        php.expr_constfetch:
+          @review comment
+          @rewrite --replace "{{fixCase(varName)}}"
+          php.name_fullyqualified:
+            name as varName
+            isIncorrectCase(varName)

--- a/tenets/codelingo/psr2/lower-case-constant-values/example-orig.php
+++ b/tenets/codelingo/psr2/lower-case-constant-values/example-orig.php
@@ -1,0 +1,15 @@
+<?php
+
+function helloWorld() {
+    print "hello world!";
+    $thing = true;
+    $thingAgain = true;
+    $thingTheThird = true;
+    $otherThing = false;
+    $another = false;
+    $andAnother = false;
+    $aNull = null;
+    $anotherNull = null;
+    $thirdNull = null;
+    
+}

--- a/tenets/codelingo/psr2/lower-case-constant-values/example-orig.php
+++ b/tenets/codelingo/psr2/lower-case-constant-values/example-orig.php
@@ -2,14 +2,14 @@
 
 function helloWorld() {
     print "hello world!";
-    $thing = true;
-    $thingAgain = true;
+    $thing = True;
+    $thingAgain = TRUE;
     $thingTheThird = true;
-    $otherThing = false;
+    $otherThing = False;
     $another = false;
-    $andAnother = false;
+    $andAnother = FALSE;
     $aNull = null;
-    $anotherNull = null;
-    $thirdNull = null;
+    $anotherNull = Null;
+    $thirdNull = NULL;
     
 }

--- a/tenets/codelingo/psr2/lower-case-constant-values/expected.json
+++ b/tenets/codelingo/psr2/lower-case-constant-values/expected.json
@@ -1,0 +1,38 @@
+[
+  {
+   "Comment": "The PHP constants true, false, and null MUST be in lower case.",
+   "Filename": "example-orig.php",
+   "Line": 12,
+   "Snippet": "    $andAnother = FALSE;\n    $aNull = null;\n    $anotherNull = Null;\n    $thirdNull = NULL;\n    "
+  },
+  {
+   "Comment": "The PHP constants true, false, and null MUST be in lower case.",
+   "Filename": "example-orig.php",
+   "Line": 5,
+   "Snippet": "function helloWorld() {\n    print \"hello world!\";\n    $thing = True;\n    $thingAgain = TRUE;\n    $thingTheThird = true;"
+  },
+  {
+   "Comment": "The PHP constants true, false, and null MUST be in lower case.",
+   "Filename": "example-orig.php",
+   "Line": 6,
+   "Snippet": "    print \"hello world!\";\n    $thing = True;\n    $thingAgain = TRUE;\n    $thingTheThird = true;\n    $otherThing = False;"
+  },
+  {
+   "Comment": "The PHP constants true, false, and null MUST be in lower case.",
+   "Filename": "example-orig.php",
+   "Line": 8,
+   "Snippet": "    $thingAgain = TRUE;\n    $thingTheThird = true;\n    $otherThing = False;\n    $another = false;\n    $andAnother = FALSE;"
+  },
+  {
+   "Comment": "The PHP constants true, false, and null MUST be in lower case.",
+   "Filename": "example-orig.php",
+   "Line": 13,
+   "Snippet": "    $aNull = null;\n    $anotherNull = Null;\n    $thirdNull = NULL;\n    \n}"
+  },
+  {
+   "Comment": "The PHP constants true, false, and null MUST be in lower case.",
+   "Filename": "example-orig.php",
+   "Line": 10,
+   "Snippet": "    $otherThing = False;\n    $another = false;\n    $andAnother = FALSE;\n    $aNull = null;\n    $anotherNull = Null;"
+  }
+ ]

--- a/tenets/codelingo/psr2/lower-case-constant-values/orig.php
+++ b/tenets/codelingo/psr2/lower-case-constant-values/orig.php
@@ -1,0 +1,15 @@
+<?php
+
+function helloWorld() {
+    print "hello world!";
+    $thing = True;
+    $thingAgain = TRUE;
+    $thingTheThird = true;
+    $otherThing = False;
+    $another = false;
+    $andAnother = FALSE;
+    $aNull = null;
+    $anotherNull = Null;
+    $thirdNull = NULL;
+    
+}


### PR DESCRIPTION
From PSR2:

## 2.5. Keywords and True/False/Null
PHP keywords MUST be in lower case.

The PHP constants true, false, and null MUST be in lower case.