### PR TITLE
Remove absent tenet from bundle file

### DIFF
--- a/tenets/codelingo/php/lingo_bundle.yaml
+++ b/tenets/codelingo/php/lingo_bundle.yaml
@@ -8,7 +8,6 @@ tenets:
 - if-assignment
 - offsite-redirection
 - phplint
-- sql-concats
 - null-check
 tags:
 - php


### PR DESCRIPTION
This was causing a user error

`github.com/mikkoaf/pineapple-goggles hit a bot error: 404: Not Found  there's no tenet called "sql-concats" at github.com/codelingo/codelingo/tenets/codelingo/php
/home/vagrant/go/src/github.com/codelingo/platform/flow/bots/parse/parse.go:97: 404: Not Found
there's no tenet called "sql-concats" at github.com/codelingo/codelingo/tenets/codelingo/php`