### PR TITLE
Add tenet to ensure responses are closed for go-cos Object struct

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -226,6 +226,17 @@ codelingo:
         hasIssues: false
     tags:
     - php
+  mozillazg-go-cos:
+    description: Tenets written for mozillazg/go-cos.
+    version: 0.0.0
+    tenets:
+      always-close-object-response-body:
+        hasIssues: false
+    tags:
+    - golang
+    - go
+    - go-cos
+    - mozillazg
   php:
     description: Best practices for PHP.
     version: 0.0.0

--- a/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/codelingo.yaml
+++ b/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/codelingo.yaml
@@ -1,0 +1,47 @@
+tenets:
+  - name:  always-close-object-response-body
+    flows:
+      codelingo/review:
+        comment: Close the response when you are done to recycle connections.
+    query: |
+      import codelingo/ast/go
+      
+      go.func_decl(depth = any):
+        @review comment
+        go.assign_stmt(depth = any):
+          go.lhs:
+            go.ident:
+              sibling_order == 0
+              name as varName
+          go.rhs:
+            go.call_expr:
+              go.selector_expr:
+                go.selector_expr:
+                  go.ident
+                  go.ident:
+                    name == "Object"
+                any_of:
+                  go.ident:
+                    name == "Get"
+                  go.ident:
+                    name == "Put"
+                  go.ident:
+                    name == "Head"
+                  go.ident:
+                    name == "Append"
+                  go.ident:
+                    name == "UploadPart"
+                  go.ident:
+                    name == "Delete"
+                  go.ident:
+                    name == "Options"
+        exclude:
+          go.call_expr(depth = any):
+            go.selector_expr:
+              go.selector_expr:
+                go.ident:
+                  name == varName
+                go.ident:
+                  name == "Body"
+              go.ident:
+                name == "Close"

--- a/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/expected.json
+++ b/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/expected.json
@@ -1,0 +1,8 @@
+[
+  {
+   "Comment": "Close the response when you are done to recycle connections.",
+   "Filename": "main.go",
+   "Line": 13,
+   "Snippet": "func main() {\n\tvar c client\n\t_, err := c.Object.Put()\n\tif err != nil {\n\t\tpanic(err)"
+  }
+ ]

--- a/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/lingo_bundle.yaml
+++ b/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/lingo_bundle.yaml
@@ -1,0 +1,9 @@
+description: Tenets written for mozillazg/go-cos.
+version: 0.0.0
+tenets:
+- always-close-object-response-body
+tags:
+- golang
+- go
+- go-cos
+- mozillazg

--- a/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/main.go
+++ b/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/main.go
@@ -1,0 +1,22 @@
+package main
+
+import "fmt"
+
+type object int
+
+type client struct {
+	Object object
+}
+
+func main() {
+	var c client
+	_, err := c.Object.Put()
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (o *object) Put() (int, error) {
+	fmt.Println("put")
+	return 1, nil
+}

--- a/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/main.go
+++ b/tenets/codelingo/mozillazg-go-cos/always-close-object-response-body/main.go
@@ -10,7 +10,7 @@ type client struct {
 
 func main() {
 	var c client
-	_, err := c.Object.Put()
+	_, err := c.Object.Put() // ISSUE
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This will match most of the Object methods that return responses. There's a couple of methods not caught as they have the response in a different position in the returns field list. 