### PR TITLE
Underscore exception

### DIFF
--- a/tenets/codelingo/effective-go/underscores-in-name/codelingo.yaml
+++ b/tenets/codelingo/effective-go/underscores-in-name/codelingo.yaml
@@ -26,7 +26,7 @@ tenets:
   - name: underscores-in-name
     flows:
       codelingo/review:
-        comment: The convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword names.
+        comment: Use MixedCaps or mixedCaps rather than underscores to write multiword names. From [Effective Go](https://golang.org/doc/effective_go.html#mixed-caps).
     query: |
       import codelingo/ast/go
       go.file(depth = any):

--- a/tenets/codelingo/effective-go/underscores-in-name/codelingo.yaml
+++ b/tenets/codelingo/effective-go/underscores-in-name/codelingo.yaml
@@ -1,12 +1,20 @@
 funcs:
-  - name: containsUnderscores
+  - name: containsInvalidUnderscores
     type: asserter
     body: |
       function(name) {
         if (name.length === 1) {
           return false
         }
-        return name.indexOf("_") !== -1
+
+        var location = name.indexOf("_")
+        if (location === -1) {
+          return false
+        }
+
+        // Underscores are valid if they're in-between two digits
+        var digits = '0123456789'
+        return digits.indexOf(name.charAt(location + 1)) === -1 || digits.indexOf(name.charAt(location - 1)) === -1
       }
   - name: isNotProto
     type: asserter
@@ -28,4 +36,4 @@ tenets:
         @review comment
         go.ident(depth = any):
           name as varName
-          containsUnderscores(varName)
+          containsInvalidUnderscores(varName)

--- a/tenets/codelingo/effective-go/underscores-in-name/example.go
+++ b/tenets/codelingo/effective-go/underscores-in-name/example.go
@@ -1,9 +1,12 @@
 // Package main used for testing of tenet
 package main
 
+import "fmt"
+
 func main() {
 	var a = 15
 	a_bad_name := 20
+	HashSHA512_384 := func() {} // A reasonable exception
 	var another_bad_name = "hello"
 	aGoodVar := 2
 }
@@ -20,6 +23,7 @@ func a_bad_function() {
 type Bad_Interface interface {
 	SomeMethod() int
 }
+
 // BetterInterface used as example
 type BetterInterface interface {
 	SomeMethod() int


### PR DESCRIPTION
Make exception for underscores surrounded by digits like `HashSHA512_384`. Discovered in the wild [here](https://github.com/thrasher-/gocryptotrader/pull/315/files#r294140233).