### PR TITLE
exclude other branch stmts

### DIFF
--- a/tenets/codelingo/go/break-select-in-for/codelingo.yaml
+++ b/tenets/codelingo/go/break-select-in-for/codelingo.yaml
@@ -13,6 +13,7 @@ tenets:
       go.for_stmt(depth = any):
         go.select_stmt(depth = any):
           go.branch_stmt(depth = any):
+            tok == "break"
             exclude:
               go.ident
 


### PR DESCRIPTION
Prevents matching on 'continue' etc