### PR TITLE
Add tenet and update registry

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -153,6 +153,8 @@ codelingo:
         hasIssues: false
       ignore-goroutine-return-values:
         hasIssues: false
+      pass-struct-by-pointer:
+        hasIssues: false
     tags:
     - golang
     - go

--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -25,6 +25,7 @@ tenets:
 - unused-private-functions
 - ignore-goroutine-return-values
 - ignore-defered-returns
+- pass-struct-by-pointer
 tags:
 - golang
 - go

--- a/tenets/codelingo/go/pass-struct-by-pointer/codelingo.yaml
+++ b/tenets/codelingo/go/pass-struct-by-pointer/codelingo.yaml
@@ -1,0 +1,26 @@
+tenets:
+  - name: pass-struct-by-pointer
+    actions:
+      codelingo/review:
+        comment: Passing a pointer to a struct with exported fields such as {{ structName }} is bad practice as it can result in multiple process reading and writing to the same memory.
+    query: |
+      import codelingo/ast/go
+
+      go.type_spec(depth = any):
+        go.ident:
+          name as structName
+        go.struct_type:
+          go.field_list:
+            go.field:
+              go.names:
+                go.ident:
+                  name as fieldName
+                  regex(/^[A-Z]/, fieldName)
+      @review comment
+      go.func_decl(depth = any):
+        go.field_list(depth = any):
+          go.field:
+            go.names
+            go.star_expr:
+              go.ident: 
+                name == structName

--- a/tenets/codelingo/go/pass-struct-by-pointer/codelingo.yaml
+++ b/tenets/codelingo/go/pass-struct-by-pointer/codelingo.yaml
@@ -14,8 +14,7 @@ tenets:
             go.field:
               go.names:
                 go.ident:
-                  name as fieldName
-                  regex(/^[A-Z]/, fieldName)
+                  private == "false"
       @review comment
       go.func_decl(depth = any):
         go.field_list(depth = any):

--- a/tenets/codelingo/go/pass-struct-by-pointer/example.go
+++ b/tenets/codelingo/go/pass-struct-by-pointer/example.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+)
+
+type Cat struct {
+	Name string
+	age int
+}
+
+type dog struct {
+	name string
+	age int
+}
+
+func getCatName(c *Cat) {
+	fmt.Println(c.Name) // Issue, accessing struct with exported field(s) by reference
+}
+
+func getCatAge(c Cat) { // Non Issue, passing struct by value
+	fmt.Println(c.Age)
+}
+
+func getDogName(d *dog) { // Non Issue, acessing struct with no exported fields
+	fmt.Println(d.Name)
+}
+
+func getDogAge(d dog) { // Non Issue, passing struct by value with no exported fields
+	fmt.Println(d.age)
+}
+
+func (c *Cat) getName() { // Issue, accesing struct with exported field(s) by reference
+	fmt.Pritnln(c.Name)
+}
+
+func (c Cat) getAge() { // Non Issue, passing struct by value
+	fmt.Println(c.age)
+}
+
+func main() {
+	fmt.Println("Hey")
+
+}

--- a/tenets/codelingo/go/pass-struct-by-pointer/expected.json
+++ b/tenets/codelingo/go/pass-struct-by-pointer/expected.json
@@ -1,0 +1,14 @@
+[
+  {
+   "Comment": "Passing a pointer to a struct with exported fields such as Cat is bad practice as it can result in multiple process reading and writing to the same memory.",
+   "Filename": "example.go",
+   "Line": 17,
+   "Snippet": "}\n\nfunc getCatName(c *Cat) {\n\tfmt.Println(c.Name) // Issue, accessing struct with exported field(s) by reference\n}\n\nfunc getCatAge(c Cat) { // Non Issue, passing struct by value"
+  },
+  {
+   "Comment": "Passing a pointer to a struct with exported fields such as Cat is bad practice as it can result in multiple process reading and writing to the same memory.",
+   "Filename": "example.go",
+   "Line": 33,
+   "Snippet": "}\n\nfunc (c *Cat) getName() { // Issue, accesing struct with exported field(s) by reference\n\tfmt.Pritnln(c.Name)\n}\n\nfunc (c Cat) getAge() { // Non Issue, passing struct by value"
+  }
+ ]


### PR DESCRIPTION
This Tenet/Standard/Spec catches situations where a function is accessing a struct type with exported fields by reference. This can lead to multiple functions, possibly operating on different go-routines, to make read and writes to the same memory at the same time and is generally an anti-pattern.