### PR TITLE
Add non-exiting-goroutine tenet.

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -133,6 +133,8 @@ codelingo:
         hasIssues: false
       nil-only-functions:
         hasIssues: true
+      non-exiting-goroutine:
+        hasIssues: true
       println-format-strings:
         hasIssues: false
       reallocated-slice:

--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -11,6 +11,7 @@ tenets:
 - init
 - marshalling
 - nil-only-functions
+- non-exiting-goroutine
 - println-format-strings
 - reallocated-slice
 - remove-break-statement

--- a/tenets/codelingo/go/non-exiting-goroutine/codelingo.yaml
+++ b/tenets/codelingo/go/non-exiting-goroutine/codelingo.yaml
@@ -1,0 +1,78 @@
+tenets:
+  - name: non-exiting-goroutine
+    actions:
+      codelingo/review:
+        comment: This goroutine does not exit and may cause a resource leak.
+    query: |
+      import codelingo/ast/go
+
+      go.go_stmt(depth = any):
+        go.call_expr:
+          any_of:
+            # Match all non-labeled for loops
+            # TODO: investigate whether include depth issue preventing us from finding nested non-labeled for loops
+            # https://github.com/codelingo/codelingo/issues/455
+            exclude:
+              go.labeled_stmt(depth = any):
+                include:
+                  @review comment
+                  go.for_stmt(depth = any):
+                    # Assert that we don't return from the for loop
+                    exclude:
+                      go.element:
+                        exclude:
+                          # Returns found inside func literals will not break the for loop
+                          go.func_lit(depth = any):
+                            include:
+                              go.return_stmt(depth = any)
+                    # Assert that we don't break using a break statement where the for loop is the
+                    # innermost "for", "switch", or "select" statement within the same function.
+                    # https://golang.org/ref/spec#Break_statements
+                    exclude:
+                      go.element:
+                        exclude:
+                          # TODO: assert that the break statement has no other for loop of select parents as
+                          # well as switch parents. https://github.com/codelingo/codelingo/issues/457
+                          go.switch_stmt(depth = any):
+                            include:
+                              go.branch_stmt(depth = any):
+                                tok == "break"
+                                exclude:
+                                  go.ident
+
+            # Match all labeled for loops
+            # TODO: use fragments to reduce code repetition between labeled and non-labeled sections
+            go.labeled_stmt(depth = any):
+              go.ident:
+                name as label
+              @review comment
+              go.for_stmt:
+                # Assert that we don't return from the for loop
+                exclude:
+                  go.element:
+                    exclude:
+                      # Returns found inside func literals will not break the for loop
+                      go.func_lit(depth = any):
+                        include:
+                          go.return_stmt(depth = any)
+                # Assert that we don't break to the for loop's label
+                exclude:
+                  go.branch_stmt(depth = any):
+                    tok == "break"
+                    go.ident:
+                      name == label
+
+                # Assert that we don't break using a break statement where the for loop is the
+                # innermost "for", "switch", or "select" statement within the same function.
+                #  https://golang.org/ref/spec#Break_statements
+                exclude:
+                  go.element:
+                    exclude:
+                      # TODO: assert that the break statement has no other for loop of select parents as
+                      # well as switch parents. https://github.com/codelingo/codelingo/issues/457
+                      go.switch_stmt(depth = any):
+                        include:
+                          go.branch_stmt(depth = any):
+                            tok == "break"
+                            exclude:
+                              go.ident

--- a/tenets/codelingo/go/non-exiting-goroutine/example.go
+++ b/tenets/codelingo/go/non-exiting-goroutine/example.go
@@ -1,0 +1,78 @@
+package main
+
+func main() {
+	go func() {
+	l:
+		for { // ISSUE - labeled simple infinite loop
+		}
+	}()
+
+	go func() {
+	l:
+		for {
+			return
+		}
+	}()
+
+	go func() {
+	l:
+		for { // ISSUE - labeled loop with an out of scope return child
+			func() {
+				return
+			}()
+		}
+	}()
+
+	go func() {
+	l:
+		for {
+			break
+		}
+	}()
+
+	go func() { // ISSUE - non-labeled simple infinite loop
+		for {
+		}
+	}()
+
+	go func() {
+		for {
+			return
+		}
+	}()
+
+	go func() { // ISSUE - non-labeled loop with an out of scope return child
+		for {
+			func() {
+				return
+			}()
+		}
+	}()
+
+	go func() {
+		for {
+			break
+		}
+	}()
+
+	go func() { // ISSUE - labeled loop with inapplicable break statement
+	l:
+		for {
+			switch 1 {
+			case 1:
+				break
+			}
+		}
+	}()
+
+	go func() {
+	l:
+		for {
+			switch 1 {
+			case 1:
+				break l
+			}
+		}
+	}()
+
+}

--- a/tenets/codelingo/go/non-exiting-goroutine/expected.json
+++ b/tenets/codelingo/go/non-exiting-goroutine/expected.json
@@ -1,0 +1,32 @@
+[
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 6,
+   "Snippet": "\tgo func() {\n\tl:\n\t\tfor { // ISSUE - labeled simple infinite loop\n\t\t}\n\t}()\n"
+  },
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 19,
+   "Snippet": "\tgo func() {\n\tl:\n\t\tfor { // ISSUE - labeled loop with an out of scope return child\n\t\t\tfunc() {\n\t\t\t\treturn\n\t\t\t}()\n\t\t}\n\t}()\n"
+  },
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 45,
+   "Snippet": "\n\tgo func() { // ISSUE - non-labeled loop with an out of scope return child\n\t\tfor {\n\t\t\tfunc() {\n\t\t\t\treturn\n\t\t\t}()\n\t\t}\n\t}()\n"
+  },
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 34,
+   "Snippet": "\n\tgo func() { // ISSUE - non-labeled simple infinite loop\n\t\tfor {\n\t\t}\n\t}()\n"
+  },
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 60,
+   "Snippet": "\tgo func() { // ISSUE - labeled loop with inapplicable break statement\n\tl:\n\t\tfor {\n\t\t\tswitch 1 {\n\t\t\tcase 1:\n\t\t\t\tbreak\n\t\t\t}\n\t\t}\n\t}()\n"
+  }
+ ]

--- a/tenets/codelingo/go/non-exiting-goroutine/issues.yaml
+++ b/tenets/codelingo/go/non-exiting-goroutine/issues.yaml
@@ -1,0 +1,2 @@
+issues:
+  - https://github.com/codelingo/codelingo/issues/457


### PR DESCRIPTION
Add tenet that catches goroutines that are guaranteed not to exit.

Is known to miss issues where a we interpret a break statement that applies to a child for loop or select statement as applying to the parent for loop due to https://github.com/codelingo/codelingo/issues/457.