### PR TITLE
Fix false negative bug.

### DIFF
--- a/tenets/codelingo/go/non-exiting-goroutine/codelingo.yaml
+++ b/tenets/codelingo/go/non-exiting-goroutine/codelingo.yaml
@@ -31,14 +31,21 @@ tenets:
                     exclude:
                       go.element:
                         exclude:
-                          # TODO: assert that the break statement has no other for loop of select parents as
-                          # well as switch parents. https://github.com/codelingo/codelingo/issues/457
-                          go.switch_stmt(depth = any):
-                            include:
-                              go.branch_stmt(depth = any):
-                                tok == "break"
-                                exclude:
-                                  go.ident
+                          any_of:
+                            go.for_stmt(depth = any):
+                              include:
+                                go.branch_stmt(depth = any):
+                                  tok == "break"
+                            go.select_stmt(depth = any):
+                              include:
+                                go.branch_stmt(depth = any):
+                                  tok == "break"
+                            go.switch_stmt(depth = any):
+                              include:
+                                go.branch_stmt(depth = any):
+                                  tok == "break"
+                                  exclude:
+                                    go.ident
 
             # Match all labeled for loops
             # TODO: use fragments to reduce code repetition between labeled and non-labeled sections
@@ -68,11 +75,18 @@ tenets:
                 exclude:
                   go.element:
                     exclude:
-                      # TODO: assert that the break statement has no other for loop of select parents as
-                      # well as switch parents. https://github.com/codelingo/codelingo/issues/457
-                      go.switch_stmt(depth = any):
-                        include:
-                          go.branch_stmt(depth = any):
-                            tok == "break"
-                            exclude:
-                              go.ident
+                      any_of:
+                        go.for_stmt(depth = any):
+                          include:
+                            go.branch_stmt(depth = any):
+                              tok == "break"
+                        go.select_stmt(depth = any):
+                          include:
+                            go.branch_stmt(depth = any):
+                              tok == "break"
+                        go.switch_stmt(depth = any):
+                          include:
+                            go.branch_stmt(depth = any):
+                              tok == "break"
+                              exclude:
+                                go.ident

--- a/tenets/codelingo/go/non-exiting-goroutine/example.go
+++ b/tenets/codelingo/go/non-exiting-goroutine/example.go
@@ -2,20 +2,17 @@ package main
 
 func main() {
 	go func() {
-	l:
 		for { // ISSUE - labeled simple infinite loop
 		}
 	}()
 
 	go func() {
-	l:
 		for {
 			return
 		}
 	}()
 
 	go func() {
-	l:
 		for { // ISSUE - labeled loop with an out of scope return child
 			func() {
 				return
@@ -24,7 +21,6 @@ func main() {
 	}()
 
 	go func() {
-	l:
 		for {
 			break
 		}
@@ -62,6 +58,7 @@ func main() {
 			case 1:
 				break
 			}
+			continue l
 		}
 	}()
 
@@ -70,6 +67,57 @@ func main() {
 		for {
 			switch 1 {
 			case 1:
+				break l
+			}
+		}
+	}()
+
+	go func() { // ISSUE - labeled loop with inapplicable break statement
+	l:
+		for {
+			select {
+			case <-make(chan int):
+				break
+			}
+			continue l
+		}
+	}()
+
+	go func() {
+	l:
+		for {
+			select {
+			case <-make(chan int):
+				break l
+			}
+		}
+	}()
+
+	go func() { // ISSUE - labeled loop with inapplicable break statement
+	l:
+		for {
+			for {
+				break
+			}
+			continue l
+		}
+	}()
+
+	go func() { // ISSUE - labeled loop with inapplicable break statement
+	l:
+		for {
+		m:
+			for {
+				break m
+			}
+			continue l
+		}
+	}()
+
+	go func() {
+	l:
+		for {
+			for {
 				break l
 			}
 		}

--- a/tenets/codelingo/go/non-exiting-goroutine/expected.json
+++ b/tenets/codelingo/go/non-exiting-goroutine/expected.json
@@ -2,31 +2,49 @@
   {
    "Comment": "This goroutine does not exit and may cause a resource leak.",
    "Filename": "example.go",
-   "Line": 6,
-   "Snippet": "\tgo func() {\n\tl:\n\t\tfor { // ISSUE - labeled simple infinite loop\n\t\t}\n\t}()\n"
-  },
-  {
-   "Comment": "This goroutine does not exit and may cause a resource leak.",
-   "Filename": "example.go",
-   "Line": 19,
-   "Snippet": "\tgo func() {\n\tl:\n\t\tfor { // ISSUE - labeled loop with an out of scope return child\n\t\t\tfunc() {\n\t\t\t\treturn\n\t\t\t}()\n\t\t}\n\t}()\n"
-  },
-  {
-   "Comment": "This goroutine does not exit and may cause a resource leak.",
-   "Filename": "example.go",
-   "Line": 45,
+   "Line": 41,
    "Snippet": "\n\tgo func() { // ISSUE - non-labeled loop with an out of scope return child\n\t\tfor {\n\t\t\tfunc() {\n\t\t\t\treturn\n\t\t\t}()\n\t\t}\n\t}()\n"
   },
   {
    "Comment": "This goroutine does not exit and may cause a resource leak.",
    "Filename": "example.go",
-   "Line": 34,
+   "Line": 5,
+   "Snippet": "func main() {\n\tgo func() {\n\t\tfor { // ISSUE - labeled simple infinite loop\n\t\t}\n\t}()\n"
+  },
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 30,
    "Snippet": "\n\tgo func() { // ISSUE - non-labeled simple infinite loop\n\t\tfor {\n\t\t}\n\t}()\n"
   },
   {
    "Comment": "This goroutine does not exit and may cause a resource leak.",
    "Filename": "example.go",
-   "Line": 60,
-   "Snippet": "\tgo func() { // ISSUE - labeled loop with inapplicable break statement\n\tl:\n\t\tfor {\n\t\t\tswitch 1 {\n\t\t\tcase 1:\n\t\t\t\tbreak\n\t\t\t}\n\t\t}\n\t}()\n"
+   "Line": 16,
+   "Snippet": "\n\tgo func() {\n\t\tfor { // ISSUE - labeled loop with an out of scope return child\n\t\t\tfunc() {\n\t\t\t\treturn\n\t\t\t}()\n\t\t}\n\t}()\n"
+  },
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 56,
+   "Snippet": "\tgo func() { // ISSUE - labeled loop with inapplicable break statement\n\tl:\n\t\tfor {\n\t\t\tswitch 1 {\n\t\t\tcase 1:\n\t\t\t\tbreak\n\t\t\t}\n\t\t\tcontinue l\n\t\t}\n\t}()\n"
+  },
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 77,
+   "Snippet": "\tgo func() { // ISSUE - labeled loop with inapplicable break statement\n\tl:\n\t\tfor {\n\t\t\tselect {\n\t\t\tcase \u003c-make(chan int):\n\t\t\t\tbreak\n\t\t\t}\n\t\t\tcontinue l\n\t\t}\n\t}()\n"
+  },
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 98,
+   "Snippet": "\tgo func() { // ISSUE - labeled loop with inapplicable break statement\n\tl:\n\t\tfor {\n\t\t\tfor {\n\t\t\t\tbreak\n\t\t\t}\n\t\t\tcontinue l\n\t\t}\n\t}()\n"
+  },
+  {
+   "Comment": "This goroutine does not exit and may cause a resource leak.",
+   "Filename": "example.go",
+   "Line": 108,
+   "Snippet": "\tgo func() { // ISSUE - labeled loop with inapplicable break statement\n\tl:\n\t\tfor {\n\t\tm:\n\t\t\tfor {\n\t\t\t\tbreak m\n\t\t\t}\n\t\t\tcontinue l\n\t\t}\n\t}()\n"
   }
  ]


### PR DESCRIPTION
We interpreted a break statement that applies to a child for loop or select statement as applying to the parent for loop. This meant we wrongly believed that a goroutine could be exited.

Possible since https://github.com/codelingo/codelingo/issues/457 was fixed.