### PR TITLE
Add pointer-leaves-method tenet

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -135,6 +135,8 @@ codelingo:
         hasIssues: true
       non-exiting-goroutine:
         hasIssues: true
+      pointer-leaves-method:
+        hasIssues: false
       println-format-strings:
         hasIssues: false
       reallocated-slice:

--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -12,6 +12,7 @@ tenets:
 - marshalling
 - nil-only-functions
 - non-exiting-goroutine
+- pointer-leaves-method
 - println-format-strings
 - reallocated-slice
 - remove-break-statement

--- a/tenets/codelingo/go/pointer-leaves-method/codelingo.yaml
+++ b/tenets/codelingo/go/pointer-leaves-method/codelingo.yaml
@@ -1,0 +1,32 @@
+tenets:
+  - name: pointer-leaves-method
+    actions:
+      codelingo/review:
+        comment: The receiver pointer is returned from this method. Make a copy instead.
+    query: |
+      import codelingo/ast/go
+
+      go.func_decl(depth = any):
+        go.field_list:
+          go.field:
+            go.names:
+              go.ident:
+                name as r
+            go.star_expr
+        go.block_stmt(depth = any):
+          go.assign_stmt(depth = any):
+            go.lhs:
+              go.ident:
+                name as n
+            go.rhs:
+              @review comment
+              go.key_value_expr(depth = any):
+                exclude:
+                  go.selector_expr(depth = any):
+                    include:
+                      go.ident(depth = any):
+                        name == r   
+          go.return_stmt(depth = any):
+            go.results:
+              go.ident:
+                name == n

--- a/tenets/codelingo/go/pointer-leaves-method/expected.json
+++ b/tenets/codelingo/go/pointer-leaves-method/expected.json
@@ -1,0 +1,15 @@
+[
+  {
+   "Comment": "The receiver pointer is returned from this method. Make a copy instead.",
+   "Filename": "main.go",
+   "Line": 29,
+   "Snippet": "\t\tid:   1,\n\t\tname: *b.name,\n\t\tbar:  b, // ISSUE\n\t}\n\treturn f"
+  },
+  {
+   "Comment": "The receiver pointer is returned from this method. Make a copy instead.",
+   "Filename": "race/race.go",
+   "Line": 65,
+   "Snippet": "func (n *NumHolder) NewUnsafeFirster() Firster {\n\tf := \u0026NumFirster{\n\t\tholder: n, // Issue\n\t}\n\treturn f"
+  }
+ ]
+

--- a/tenets/codelingo/go/pointer-leaves-method/main.go
+++ b/tenets/codelingo/go/pointer-leaves-method/main.go
@@ -1,0 +1,32 @@
+package main
+
+import "pointer-leaves-method/race"
+
+type Bar struct {
+	name *string
+}
+
+type Foo struct {
+	id   int
+	name string
+	bar  *Bar
+}
+
+func main() {
+	race.Race()
+}
+
+func NewBar(name string) *Bar {
+	return &Bar{
+		name: &name,
+	}
+}
+
+func (b *Bar) NewFooFromBar() *Foo {
+	f := &Foo{
+		id:   1,
+		name: *b.name,
+		bar:  b, // ISSUE
+	}
+	return f
+}

--- a/tenets/codelingo/go/pointer-leaves-method/race/race.go
+++ b/tenets/codelingo/go/pointer-leaves-method/race/race.go
@@ -1,0 +1,89 @@
+package race
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Firster interface
+type Firster interface {
+	// First returns the first element in the underlying data structure
+	First() interface{}
+	// First sets the first element in the underlying data structure
+	SetFirst(interface{})
+}
+
+// NumHolder has an ID and holds a slice of ints
+type NumHolder struct {
+	id   int
+	nums []int
+}
+
+// NumFirster contains a reference to a NumHolder and implements Firster
+type NumFirster struct {
+	holder *NumHolder
+}
+
+// Race attempts to data race on an implementation of Firster
+func Race() error {
+	var wg sync.WaitGroup
+	h := NumHolder{
+		id:   1,
+		nums: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+	for i := 0; i < 10; i++ {
+		f := h.NewUnsafeFirster()
+		nf, ok := f.(*NumFirster)
+		if !ok {
+			return errors.New("failed to cast to NumFirster")
+		}
+		wg.Add(1)
+		go func(num int, nf *NumFirster) {
+			defer wg.Done()
+			nf.SetFirst(num)
+			// Do something...
+			time.Sleep(10 * time.Millisecond)
+			if first, ok := nf.First().(int); ok {
+				fmt.Printf("%p: %d\n", nf.holder, first)
+			}
+		}(i, nf)
+	}
+	wg.Wait()
+	return nil
+}
+
+// NewUnsafeFirster creates a race-unsafe NumFirster
+func (n *NumHolder) NewUnsafeFirster() Firster {
+	f := &NumFirster{
+		holder: n, // Issue
+	}
+	return f
+}
+
+// NewSafeFirster creates a race-safe NumFirster
+func (n *NumHolder) NewSafeFirster() Firster {
+	numCopy := append([]int{}, n.nums...)
+	nCopy := &NumHolder{
+		id:   n.id,
+		nums: numCopy,
+	}
+
+	f := &NumFirster{
+		holder: nCopy,
+	}
+	return f
+}
+
+// First implements Firster
+func (n *NumFirster) First() interface{} {
+	return n.holder.nums[0]
+}
+
+// SetFirst implements Firster
+func (n *NumFirster) SetFirst(num interface{}) {
+	if newFirstVal, ok := num.(int); ok {
+		n.holder.nums[0] = newFirstVal
+	}
+}


### PR DESCRIPTION
Catches cases where a method returns a struct containing the receiver pointer. Can lead to data races. You can see the results of the right way and the wrong way by switching out NewUnsafeFirster() for NewSafeFirster() in race.Race() and then running main.go