### PR TITLE
Remove-callgraph-tenets

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -152,9 +152,9 @@ codelingo:
       unconvert:
         hasIssues: false
       ignore-defered-returns:
-        hasIssues: false
+        hasIssues: true
       ignore-goroutine-return-values:
-        hasIssues: false
+        hasIssues: true
       shared-count-datarace:
         hasIssues: false
     tags:

--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -24,8 +24,6 @@ tenets:
 - unnecessary-parentheses
 - unsafe-go-routine-variables
 - unused-private-functions
-- ignore-goroutine-return-values
-- ignore-defered-returns
 - shared-count-datarace
 tags:
 - golang


### PR DESCRIPTION
Prevent not working tenets which rely on callgraph from being imported in the go bundle