### PR TITLE
Add spec to catch shadowed variables

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -147,6 +147,8 @@ codelingo:
         hasIssues: false
       remove-empty-suite-functions:
         hasIssues: false
+      shadowed-variable:
+        hasIssues: false
       sprintf:
         hasIssues: true
       tested:

--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -20,6 +20,7 @@ tenets:
 - reallocated-slice
 - remove-break-statement
 - remove-empty-suite-functions
+- shadowed-variable
 - shared-count-datarace
 - sprintf
 - tested

--- a/tenets/codelingo/go/shadowed-variable/codelingo.yaml
+++ b/tenets/codelingo/go/shadowed-variable/codelingo.yaml
@@ -1,0 +1,25 @@
+tenets:
+  - name: shadowed-variable
+    actions:
+      codelingo/review:
+        comment: Variable {{x}} shadows a variable of the same name declared in an outer scope.
+    query: |
+      import codelingo/ast/go
+
+      go.file(depth = any):
+        go.decls:
+          go.func_decl:
+            go.block_stmt:
+              go.list:
+                go.assign_stmt:
+                  go.lhs:
+                    go.ident:
+                      name as x
+                go.block_stmt(depth = any):
+                  go.list:
+                    go.assign_stmt:
+                      tok == ":="
+                      go.lhs:
+                        @review comment
+                        go.ident:
+                          name == x

--- a/tenets/codelingo/go/shadowed-variable/examples.go
+++ b/tenets/codelingo/go/shadowed-variable/examples.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	foo()
+	bar()
+}
+
+func foo() {
+	x := 1
+	fmt.Println(x)
+	{
+		x = 5  // Acceptable
+		x := 2 // Issue
+		fmt.Println(x)
+	}
+	x = x + 2
+	fmt.Println(x)
+}
+
+func bar() { //nested test
+	x := "test"
+	{
+		if x == "test" {
+			x := "newVariable" // Issue
+			fmt.Println(x)
+		}
+	}
+}

--- a/tenets/codelingo/go/shadowed-variable/expected.json
+++ b/tenets/codelingo/go/shadowed-variable/expected.json
@@ -1,0 +1,15 @@
+[
+    {
+     "Comment": "Variable x shadows a variable of the same name declared in an outer scope.",
+     "Filename": "test.go",
+     "Line": 28,
+     "Snippet": "\t{\n\t\tif x == \"test\" {\n\t\t\tx := \"newVariable\" // Issue\n\t\t\tfmt.Println(x)\n\t\t}"
+    },
+    {
+     "Comment": "Variable y shadows a variable of the same name declared in an outer scope.",
+     "Filename": "test.go",
+     "Line": 17,
+     "Snippet": "\t{\n\t\ty = 5  // Acceptable\n\t\ty := 2 // Issue\n\t\tfmt.Println(y)\n\t}"
+    }
+]
+  


### PR DESCRIPTION
This spec/tenant is able to detect when a variable is being shadowed.