### PR TITLE
reassigned error spec added

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -145,6 +145,8 @@ codelingo:
         hasIssues: false
       reallocated-slice:
         hasIssues: false
+      reassigned-error:
+        hasIssues: false
       remove-empty-suite-functions:
         hasIssues: false
       shadowed-variable:

--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -18,6 +18,7 @@ tenets:
 - pointer-leaves-method
 - println-format-strings
 - reallocated-slice
+- reassigned-error
 - remove-break-statement
 - remove-empty-suite-functions
 - shadowed-variable

--- a/tenets/codelingo/go/reassigned-error/codelingo.yaml
+++ b/tenets/codelingo/go/reassigned-error/codelingo.yaml
@@ -1,0 +1,41 @@
+funcs:
+- name: compareFunc
+  type: asserter
+  body: |
+    function (a, b) {
+      return a < b;
+    }
+- name: threeComparison
+  type: asserter
+  body: |
+    function (a, b, c) {
+      return (a < b) && (a > c);
+    }
+tenets:
+- name: error-reassign
+  actions:
+    codelingo/review:
+      comment: Error was not checked before reassignment
+  query: |
+    import codelingo/ast/go
+    go.block_stmt(depth = any):
+      go.list:
+        @review comment
+        go.assign_stmt:
+          sibling_order as so1
+          go.lhs:
+            go.ident:
+              name == "err"
+        go.assign_stmt:
+          sibling_order as so2
+          compareFunc(so1, so2)
+          go.lhs:
+            go.ident:
+              name == "err"
+        exclude:
+          go.if_stmt:
+            sibling_order as so3 
+            threeComparison(so3, so2, so1)
+            go.binary_expr:
+              go.ident:
+                name == "err"

--- a/tenets/codelingo/go/reassigned-error/example.go
+++ b/tenets/codelingo/go/reassigned-error/example.go
@@ -1,0 +1,12 @@
+package main
+import (
+    "os"
+)
+func main() {
+    file, err := os.Open("test.txt")
+    file, err = os.Open("test.txt")
+    if err != nil {
+        panic(err)
+    }
+    defer file.Close()
+}

--- a/tenets/codelingo/go/reassigned-error/expected.json
+++ b/tenets/codelingo/go/reassigned-error/expected.json
@@ -1,0 +1,8 @@
+[
+    {
+     "Comment": "Error was not checked before reassignment",
+     "Filename": "example.go",
+     "Line": 6,
+     "Snippet": "\nfunc main() {\n\tfile, err := os.Open("test.txt"),\n\tfile, err = os.Open("test.txt")"
+    }
+   ]


### PR DESCRIPTION
This spec detects when an error isn't being checked before reassignment.