### PR TITLE
Add spec to ensure Reader bytes is checked before err

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -119,6 +119,8 @@ codelingo:
         hasIssues: false
       break-select-in-for:
         hasIssues: false
+      check-reader-bytes-before-err:
+        hasIssues: false
       deprecated:
         hasIssues: false
       default-in-type-switch:

--- a/tenets/codelingo/go/check-reader-bytes-before-err/codelingo.yaml
+++ b/tenets/codelingo/go/check-reader-bytes-before-err/codelingo.yaml
@@ -1,0 +1,53 @@
+funcs:
+  - name: compareFunc
+    type: asserter
+    body: |
+      function (a, b) {
+        return a < b;
+      }
+  - name: threeComparison
+    type : asserter
+    body: |
+      function (a, b, c){
+        return (a < b) && (a > c);
+      }
+tenets:
+  - name: check-reader-bytes-before-err
+    actions:
+      codelingo/review:
+        comment: Check io.Reader bytes read (and process) before checking err
+    query: |
+      import codelingo/ast/go
+
+      go.block_stmt(depth = any):
+        go.list:
+          go.assign_stmt:
+            sibling_order as so1
+            go.lhs:
+              go.ident:
+                name == "err"
+            go.rhs:
+              go.call_expr:
+                go.selector_expr:
+                  go.ident:
+                    name == "Read"
+                go.args:
+                  go.ident:
+                    name as x
+          @review comment
+          go.if_stmt:
+            sibling_order as so2
+            compareFunc(so1, so2)
+            go.binary_expr:
+              go.ident:
+                name == "err"
+          exclude:
+            go.expr_stmt:
+              sibling_order as so3
+              threeComparison(so3, so2, so1)
+              go.call_expr:
+                go.args: 
+                  go.call_expr:
+                    go.args:
+                      go.ident:
+                        name == x

--- a/tenets/codelingo/go/check-reader-bytes-before-err/example.go
+++ b/tenets/codelingo/go/check-reader-bytes-before-err/example.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	file, err := os.Open("test.txt")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	buff := make([]byte, 6)
+
+	n, err := file.Read(buff)
+	fmt.Println("read", n, "data:", string(buff))
+	if err != nil {
+		panic(err)
+	}
+
+	n, err = file.Read(buff)
+	if err != nil { // Issue
+		panic(err)
+	}
+
+	fmt.Println("read", n, "data:", string(buff))
+
+}

--- a/tenets/codelingo/go/check-reader-bytes-before-err/expected.json
+++ b/tenets/codelingo/go/check-reader-bytes-before-err/expected.json
@@ -1,0 +1,8 @@
+[
+    {
+     "Comment": "Check io.Reader bytes read (and process) before checking err",
+     "Filename": "example.go",
+     "Line": 24,
+     "Snippet": "\n\tn, err = file.Read(buff)\n\tif err != nil { // Issue\n\t\tpanic(err)\n\t}\n\n\tfmt.Println(\"read\", n, \"data:\", string(buff))"
+    }
+   ]

--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -4,6 +4,7 @@ tenets:
 - avoid-delayed-must-calls
 - bool-param
 - break-select-in-for
+- check-reader-bytes-before-err
 - default-in-type-switch
 - deprecated
 - empty-slice


### PR DESCRIPTION
This spec/tenant ensures that io.Reader bytes is processed before checking err