### PR TITLE
Improve shadow variable spec

### DIFF
--- a/tenets/codelingo/go/shadowed-variable/codelingo.yaml
+++ b/tenets/codelingo/go/shadowed-variable/codelingo.yaml
@@ -24,3 +24,4 @@ tenets:
                         go.ident:
                           name == x
                           name != "err"
+                          name != "_"

--- a/tenets/codelingo/go/shadowed-variable/codelingo.yaml
+++ b/tenets/codelingo/go/shadowed-variable/codelingo.yaml
@@ -23,3 +23,4 @@ tenets:
                         @review comment
                         go.ident:
                           name == x
+                          name != "err"

--- a/tenets/codelingo/go/shadowed-variable/examples.go
+++ b/tenets/codelingo/go/shadowed-variable/examples.go
@@ -2,15 +2,34 @@ package main
 
 import (
 	"fmt"
+	"os"
 )
 
 func main() {
 	foo()
 	bar()
+	baz()
+}
+
+func baz() {
+	file, err := os.Open("test.txt")
+	if err != nil {
+		return 
+	}
+	defer file.Close()
+
+	fileList := []string{"test1.txt"}
+	for _, f:= range fileList {
+		fileN, err := os.Open(f) // Acceptable
+		if err != nil {
+			return 
+		}
+		defer fileN.Close()
+	}
 }
 
 func foo() {
-	x := 1
+	x := 1	// Acceptable
 	fmt.Println(x)
 	{
 		x = 5  // Acceptable
@@ -24,9 +43,10 @@ func foo() {
 func bar() { //nested test
 	x := "test"
 	{
-		if x == "test" {
+		if true {
 			x := "newVariable" // Issue
 			fmt.Println(x)
 		}
 	}
+	fmt.Println(x)
 }


### PR DESCRIPTION
Had a lot of false positives showing that the "err" variable was being shadowed, which wasn't true so made the spec ignore "err" variables, and also ignore the "_" variable as it is just a placeholder variable.