### PR TITLE
[WIP]: Add spec to ensure channel is checked when ctx is present

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -161,6 +161,8 @@ codelingo:
         hasIssues: false
       todo:
         hasIssues: false
+      unchecked-channel-usage-when-ctx-is-present:
+        hasIssues: false
       unchecked-type-assertion:
         hasIssues: false
       unconvert:

--- a/tenets/codelingo/go/lingo_bundle.yaml
+++ b/tenets/codelingo/go/lingo_bundle.yaml
@@ -28,6 +28,7 @@ tenets:
 - tested
 - ticker-in-for-select
 - todo
+- unchecked-channel-usage-when-ctx-is-present
 - unchecked-type-assertion
 - unconvert
 - unnecessary-parentheses

--- a/tenets/codelingo/go/unchecked-channel-usage-when-ctx-is-present/codelingo.yaml
+++ b/tenets/codelingo/go/unchecked-channel-usage-when-ctx-is-present/codelingo.yaml
@@ -1,0 +1,39 @@
+tenets:
+  - name: unchecked-channel-usage-when-ctx-is-present
+    actions:
+      codelingo/review:
+        comment: Any channel operations should be guarded by {{x}}.Done() as the function takes a context in as a parameter
+    query: |
+      import codelingo/ast/go
+
+      go.file(depth = any):
+        go.decls: 
+          go.func_decl:
+            go.func_type:
+              go.field_list:
+                go.field:
+                  go.names:
+                    go.ident:
+                      name as x
+                  go.selector_expr:
+                    go.ident:
+                      name == "context"
+                    go.ident:
+                      name == "Context"
+            go.block_stmt(depth = any):
+              go.list:
+                go.go_stmt:
+                  go.call_expr:
+                    go.send_stmt(depth = any):
+                      @review comment
+                      go.ident:
+                        type == "chan string"
+                  exclude:
+                    go.expr_stmt(depth = any):
+                      go.unary_expr:
+                        go.call_expr:
+                          go.selector_expr:
+                            go.ident:
+                              name == x
+                            go.ident:
+                              name == "Done"

--- a/tenets/codelingo/go/unchecked-channel-usage-when-ctx-is-present/example.go
+++ b/tenets/codelingo/go/unchecked-channel-usage-when-ctx-is-present/example.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func foo(ctx context.Context, c chan string) {
+	go func() {
+		for i := 0; i < 5; i++ {
+			select {
+			case c <- "message":
+			case <-ctx.Done(): // Accepted
+				return
+			}
+		}
+		close(c)
+	}()
+}
+
+func bar(ctx context.Context, c1 chan string) {
+	go func() {
+		for i := 0; i < 5; i++ {
+			c1 <- "message1" // Issue
+		}
+		close(c1)
+	}()
+}
+
+func main() {
+	d := time.Now().Add(50 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), d)
+	defer cancel()
+
+	c := make(chan string)
+
+	foo(ctx, c)
+
+	for msg := range c {
+		fmt.Println(msg)
+	}
+
+	c1 := make(chan string)
+
+	bar(ctx, c1)
+
+	for msg := range c1 {
+		fmt.Println(msg)
+	}
+}

--- a/tenets/codelingo/go/unchecked-channel-usage-when-ctx-is-present/expected.json
+++ b/tenets/codelingo/go/unchecked-channel-usage-when-ctx-is-present/expected.json
@@ -1,0 +1,8 @@
+[
+    {
+     "Comment": "Any channel operations should be guarded by ctx.Done() as the function takes a context in as a parameter",
+     "Filename": "example.go",
+     "Line": 25,
+     "Snippet": "\tgo func() {\n\t\tfor i := 0; i \u003c 5; i++ {\n\t\t\tc1 \u003c- \"message1\" // Issue\n\t\t}\n\t\tclose(c1)"
+    }
+   ]


### PR DESCRIPTION
This spec/tenant ensures that when channels are used with ctx is present, channel operations are guarded by ctx.Done(). 
Requires types.