### PR TITLE
Drop public private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .DS_Store
 notes.txt
+*.swp

--- a/tenets/codelingo/code-review-comments/camel-case-constants/codelingo.yaml
+++ b/tenets/codelingo/code-review-comments/camel-case-constants/codelingo.yaml
@@ -8,16 +8,17 @@ funcs:
   - name: fixName
     type: resolver
     body: |
-      function(varName, private){
+      function(varName){
         if(varName.indexOf("_") === -1 || varName === "_"){ 
           if(varName === varName.toUpperCase() && varName.length > 4) // variable is ALLCAPS, should be changed to Allcaps
             return varName.charAt(0).toUpperCase() + varName.toLowerCase().substring(1)
           return varName // variable can be all lowercase, mixedCaps or MixedCaps or ALLCAPS with length less than 4 (we do not change acronyms of length 4 or less)
         }
+        private = !varName.match(/^[A-Z]/)
         varName = varName.toLowerCase()
         pieces = varName.split("_");
         constName = []
-        if(private == "true"){
+        if(private){
           constName.push(pieces[0])
         }
         else{
@@ -33,7 +34,7 @@ tenets:
   - name:  camel-case-constants
     actions:
       codelingo/review:
-        comment: Define constant "{{varName}}" as "{{fixName(varName, varPrivate)}}". The convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword constant names. [as specified in Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps)
+        comment: Define constant "{{varName}}" as "{{fixName(varName)}}". The convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword constant names. [as specified in Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps)
       codelingo/docs:
         title: Camel case constants
         body: |    
@@ -51,9 +52,8 @@ tenets:
           
           go.names:
             @review comment
-            @rewrite --replace "{{fixName(varName, varPrivate)}}"
+            @rewrite --replace "{{fixName(varName)}}"
             go.ident:
               name as varName
               isNotValid(varName)
-              private as varPrivate
 

--- a/tenets/codelingo/code-review-comments/camel-case-constants/expected.json
+++ b/tenets/codelingo/code-review-comments/camel-case-constants/expected.json
@@ -9,19 +9,19 @@
      "Comment": "Define constant \"PIVALUE\" as \"Pivalue\". The convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword constant names. [as specified in Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps)",
      "Filename": "test.go",
      "Line": 7,
-     "Snippet": "const Pi = 3.14\nconst PI = 3.14\nconst PIVALUE = 3.14 //ISSUE\nconst private_Pi = 3.14 //ISSUE\nconst Public_Pi = 3.14  //ISSUE"
+     "Snippet": "const Pi = 3.14\nconst PI = 3.14\nconst PIVALUE = 3.14    //ISSUE\nconst private_Pi = 3.14 //ISSUE\nconst Public_Pi = 3.14  //ISSUE"
     },
     {
      "Comment": "Define constant \"private_Pi\" as \"privatePi\". The convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword constant names. [as specified in Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps)",
      "Filename": "test.go",
      "Line": 8,
-     "Snippet": "const PI = 3.14\nconst PIVALUE = 3.14 //ISSUE\nconst private_Pi = 3.14 //ISSUE\nconst Public_Pi = 3.14  //ISSUE\nconst PUBLIC_PI = 3.14  //ISSUE"
+     "Snippet": "const PI = 3.14\nconst PIVALUE = 3.14    //ISSUE\nconst private_Pi = 3.14 //ISSUE\nconst Public_Pi = 3.14  //ISSUE\nconst PUBLIC_PI = 3.14  //ISSUE"
     },
     {
      "Comment": "Define constant \"Public_Pi\" as \"PublicPi\". The convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword constant names. [as specified in Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps)",
      "Filename": "test.go",
      "Line": 9,
-     "Snippet": "const PIVALUE = 3.14 //ISSUE\nconst private_Pi = 3.14 //ISSUE\nconst Public_Pi = 3.14  //ISSUE\nconst PUBLIC_PI = 3.14  //ISSUE\n"
+     "Snippet": "const PIVALUE = 3.14    //ISSUE\nconst private_Pi = 3.14 //ISSUE\nconst Public_Pi = 3.14  //ISSUE\nconst PUBLIC_PI = 3.14  //ISSUE\n"
     },
     {
      "Comment": "Define constant \"private_World\" as \"privateWorld\". The convention in Go is to use MixedCaps or mixedCaps rather than underscores to write multiword constant names. [as specified in Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments#mixed-caps)",

--- a/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml
+++ b/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml
@@ -11,6 +11,13 @@ funcs:
 
         return !filename.endsWith("_test.go")
       }
+  - name: isExported
+    type: asserter
+    body: |
+      function(name) {
+        // TODO: support unicode uppercase
+        return !!name.match(/^[A-Z]/)
+      }
   - name: isValid
     type: asserter
     body: |
@@ -306,6 +313,6 @@ tenets:
               sibling_order == 0
               text as commText
           go.ident:
-            public == "true"
             name as funcName
+            isExported(funcName)
             isValid(commText, funcName)

--- a/tenets/codelingo/effective-go/comment-first-word-when-empty/codelingo.yaml
+++ b/tenets/codelingo/effective-go/comment-first-word-when-empty/codelingo.yaml
@@ -11,6 +11,13 @@ funcs:
 
         return !filename.endsWith("_test.go")
       }
+  - name: isExported
+    type: asserter
+    body: |
+      function(name) {
+        // TODO: support unicode uppercase
+        return !!name.match(/^[A-Z]/)
+      }
 tenets:
   - name: comment-first-word-when-empty
     actions:
@@ -33,4 +40,4 @@ tenets:
             go.comment_group
           go.ident:
             name as funcName
-            public == "true"
+            isExported(funcName)

--- a/tenets/codelingo/effective-go/comment-first-word-when-empty/expected.json
+++ b/tenets/codelingo/effective-go/comment-first-word-when-empty/expected.json
@@ -1,8 +1,8 @@
 [
   {
-   "Comment": "The first sentence should be a one-sentence summary that starts with the name (Unnamed) being declared.\n",
+   "Comment": "Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name (Unnamed) being declared.\n",
    "Filename": "example.go",
    "Line": 3,
    "Snippet": "package main\n\nfunc Unnamed() {}\n"
   }
- ]
+]

--- a/tenets/codelingo/effective-go/update-comment-first-word-as-subject/codelingo.yaml
+++ b/tenets/codelingo/effective-go/update-comment-first-word-as-subject/codelingo.yaml
@@ -11,6 +11,13 @@ funcs:
 
         return !filename.endsWith("_test.go")
       }
+  - name: isExported
+    type: asserter
+    body: |
+      function(name) {
+        // TODO: support unicode uppercase
+        return !!name.match(/^[A-Z]/)
+      }
   - name: isValid
     type: asserter
     body: |
@@ -294,6 +301,6 @@ tenets:
               sibling_order == 0
               text as commText
           go.ident:
-            public == "true"
             name as funcName
+            isExported(funcName)
             isValid(commText, funcName)

--- a/tenets/codelingo/go/tested/codelingo.yaml
+++ b/tenets/codelingo/go/tested/codelingo.yaml
@@ -17,6 +17,13 @@ funcs:
       function (str, substr) {
         return str.indexOf(substr) == -1
       }
+  - name: isExported
+    type: asserter
+    body: |
+      function(name) {
+        // TODO: support unicode uppercase
+        return !!name.match(/^[A-Z]/)
+      }
 tenets:
   - name: find-funcs
     actions:
@@ -34,8 +41,8 @@ tenets:
           @review comment
           go.func_decl:
             go.ident:
-              public == "true"
               name as funcName
+              isExported(funcName)
       exclude:
         go.file(depth = any):
           filename == testFile(filename)

--- a/tenets/codelingo/go/tested/expected.json
+++ b/tenets/codelingo/go/tested/expected.json
@@ -1,45 +1,14 @@
 [
   {
-   "name": "find-funcs",
-   "position": {
-    "start": {
-     "filename": "main.go",
-     "Offset": 90,
-     "Line": 9,
-     "Column": 1
-    },
-    "end": {
-     "filename": "main.go",
-     "Offset": 111,
-     "Line": 9,
-     "Column": 22
-    }
-   },
-   "comment": "This exported function does not have a corresponding test function.",
-   "ctxBefore": "\n// SecondPrint also prints",
-   "lineText": "func SecondPrint() {}",
-   "newCode": true
+   "Comment": "This exported function does not have a corresponding test function.",
+   "Filename": "example.go",
+   "Line": 12,
+   "Snippet": "\n// No test function\nfunc (a *aStruct) SayA() string {\n\tif a.b == nil {\n\t\treturn \"end\"\n\t}\n\treturn \"I'm a \" // + a.b.SayB()\n}\n\ntype bStruct struct {"
   },
   {
-   "name": "find-funcs",
-   "position": {
-    "start": {
-     "filename": "example.go",
-     "Offset": 94,
-     "Line": 12,
-     "Column": 1
-    },
-    "end": {
-     "filename": "example.go",
-     "Offset": 197,
-     "Line": 17,
-     "Column": 2
-    }
-   },
-   "comment": "This exported function does not have a corresponding test function.",
-   "ctxBefore": "\n// No test function",
-   "lineText": "func (a *aStruct) SayA() string {\n\tif a.b == nil {\n\t\treturn \"end\"\n\t}\n\treturn \"I'm a \" // + a.b.SayB()\n}",
-   "ctxAfter": "\ntype bStruct struct {",
-   "newCode": true
+   "Comment": "This exported function does not have a corresponding test function.",
+   "Filename": "main.go",
+   "Line": 9,
+   "Snippet": "\n// SecondPrint also prints\nfunc SecondPrint() {}\n"
   }
  ]

--- a/tenets/codelingo/go/unused-private-functions/codelingo.yaml
+++ b/tenets/codelingo/go/unused-private-functions/codelingo.yaml
@@ -1,8 +1,11 @@
 funcs:
-  - name: isUnexported
+  - name: isCandidate
     type: asserter
     body: |
       function(name) {
+        if (name == "main" || name == "init") {
+          return false
+        }
         // TODO: support unicode uppercase
         return !name.match(/^[A-Z]/)
       }
@@ -20,10 +23,8 @@ tenets:
           @review comment
           go.ident:
             name as funcName
-            isUnexported(funcName)
-            name != "main"
-            name != "init"
+            isCandidate(funcName)
         exclude:
           go.call_expr(depth = any):
             go.ident:
-              name as funcName
+              name == funcName

--- a/tenets/codelingo/go/unused-private-functions/codelingo.yaml
+++ b/tenets/codelingo/go/unused-private-functions/codelingo.yaml
@@ -1,3 +1,11 @@
+funcs:
+  - name: isUnexported
+    type: asserter
+    body: |
+      function(name) {
+        // TODO: support unicode uppercase
+        return !name.match(/^[A-Z]/)
+      }
 tenets:
   - name: find-unused-private-funcs
     actions:
@@ -11,8 +19,8 @@ tenets:
         go.func_decl(depth = any):
           @review comment
           go.ident:
-            private == "true"
             name as funcName
+            isUnexported(funcName)
             name != "main"
             name != "init"
         exclude:


### PR DESCRIPTION
golang public/private properties are wrong in many ways:

* strings not bools
* badly named
* like 8% of all our edges in the DB despite being just "is the first letter a capital"

This PR drops all usage of public/private from our specs, in preparation for dropping support for them in platform.