### PR TITLE
Create registry consistency checker.

### DIFF
--- a/registry/tenets.yaml
+++ b/registry/tenets.yaml
@@ -173,8 +173,8 @@ codelingo:
         hasIssues: false
       avoid-delayed-must-calls:
         hasIssues: false
-      async-writes-to-pointer:
-        hasIssues: true
+      writes-to-async-pointer:
+        hasIssues: false
       insecure-http-connection:
         hasIssues: false
       concurrent-use-of-rand:
@@ -254,16 +254,6 @@ codelingo:
     - lnd
     - golang
     - go
-  modica:
-    description: Tenets written for Modica
-    version: 0.0.0
-    tenets:
-      null-check:
-        hasIssues: false
-      transport:
-        hasIssues: false
-    tags:
-    - php
   mozillazg-go-cos:
     description: Tenets written for mozillazg/go-cos.
     version: 0.0.0
@@ -292,8 +282,6 @@ codelingo:
       offsite-redirection:
         hasIssues: false
       phplint:
-        hasIssues: false
-      sql-concats:
         hasIssues: false
     tags:
     - php
@@ -365,13 +353,3 @@ codelingo:
     - go
     - lomik
     - go-carbon
-  dev:
-    description: Tenets tested in dev-lexicons
-    version: 0.0.0
-    tenets:
-      potential-nil-pointer:
-        hasIssues: false
-    tags:
-    - go
-    - golang
-

--- a/util/registry/main.go
+++ b/util/registry/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"gopkg.in/yaml.v1"
+)
+
+func main() {
+	actualRules := getActualRules()
+	statedRules := getStatedRules()
+	missingActualRules := []string{}
+	missingStatedRules := []string{}
+
+	for rule := range actualRules {
+		if _, ok := statedRules[rule]; !ok {
+			missingStatedRules = append(missingStatedRules, rule)
+		}
+	}
+
+	for rule := range statedRules {
+		if _, ok := actualRules[rule]; !ok {
+			missingActualRules = append(missingActualRules, rule)
+		}
+	}
+
+	fmt.Println("Missing Stated Rules: ", missingStatedRules)
+	fmt.Println("Missing Actual Rules: ", missingActualRules)
+}
+
+func getStatedRules() map[string]bool {
+	rules := map[string]bool{}
+	gopath := os.Getenv("GOPATH")
+	registryPath := path.Join(gopath, "src/github.com/codelingo/codelingo/registry/tenets.yaml")
+
+	registryContents, err := ioutil.ReadFile(registryPath)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	r := map[interface{}]map[interface{}]map[interface{}]map[interface{}]interface{}{}
+	yaml.Unmarshal(registryContents, &r)
+	for o, bundles := range r {
+		owner := o.(string)
+		for b, contents := range bundles {
+			bundle := b.(string)
+			for key, ruleList := range contents {
+				k := key.(string)
+				if k != "tenets" {
+					continue
+				}
+				for r := range ruleList {
+					rule := r.(string)
+					rules[path.Join(owner, bundle, rule)] = true
+				}
+			}
+		}
+	}
+	return rules
+}
+
+func getActualRules() map[string]bool {
+	gopath := os.Getenv("GOPATH")
+	rulesPath := path.Join(gopath, "src/github.com/codelingo/codelingo/tenets")
+
+	rules := map[string]bool{}
+
+	owners, err := ioutil.ReadDir(rulesPath)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	for _, owner := range owners {
+		if owner.IsDir() {
+			bundles, err := ioutil.ReadDir(path.Join(rulesPath, owner.Name()))
+			if err != nil {
+				panic(err.Error())
+			}
+
+			for _, bundle := range bundles {
+				if bundle.IsDir() {
+					ruleDirs, err := ioutil.ReadDir(path.Join(rulesPath, owner.Name(), bundle.Name()))
+					if err != nil {
+						panic(err.Error())
+					}
+
+					for _, rule := range ruleDirs {
+						if rule.IsDir() {
+							rules[path.Join(owner.Name(), bundle.Name(), rule.Name())] = true
+						}
+					}
+				}
+			}
+
+		}
+	}
+
+	return rules
+}


### PR DESCRIPTION
Make sure every rule in the registry actually exists in the repo.

The reverse is not true yet, since it probably isn't causing any dashboard problems. However, this utility does tell us which rules aren't used, and it wouldn't be that hard to make it generate the registry file.